### PR TITLE
Remove PdgParticle.is_generic

### DIFF
--- a/pdg/particle.py
+++ b/pdg/particle.py
@@ -393,30 +393,22 @@ class PdgParticle(PdgData):
         return 'B' in self.data_flags
 
     @property
-    def is_generic(self):
-        """True if particle represents a generic charge state."""
-        return self._get_particle_data()['cc_type'] == 'S'
-
-    @property
     def mass(self):
         """Mass of the particle in GeV."""
-        best_mass_property = best(self.masses(), self.api.pedantic, '%s mass (%s)' % (self.name, self.pdgid),
-                                  self.is_generic)
+        best_mass_property = best(self.masses(), self.api.pedantic, '%s mass (%s)' % (self.name, self.pdgid))
         return best_mass_property.best_summary().get_value('GeV')
 
     @property
     def mass_error(self):
         """Symmetric error on mass of particle in GeV, or None if mass error are asymmetric or mass is a limit."""
-        best_mass_property = best(self.masses(), self.api.pedantic, '%s (%s)' % (self.pdgid, self.description),
-                                  self.is_generic)
+        best_mass_property = best(self.masses(), self.api.pedantic, '%s (%s)' % (self.pdgid, self.description))
         return best_mass_property.best_summary().get_error('GeV')
 
     @property
     def width(self):
         """Width of the particle in GeV."""
         try:
-            best_width_property = best(self.widths(), self.api.pedantic, '%s width (%s)' % (self.name, self.pdgid),
-                                       self.is_generic)
+            best_width_property = best(self.widths(), self.api.pedantic, '%s width (%s)' % (self.name, self.pdgid))
             return best_width_property.best_summary().get_value('GeV')
         except PdgNoDataError:
             if self.api.pedantic:
@@ -430,8 +422,7 @@ class PdgParticle(PdgData):
     def width_error(self):
         """Symmetric error on width of particle in GeV, or None if width error are asymmetric or width is a limit."""
         try:
-            best_width_property = best(self.widths(), self.api.pedantic, '%s (%s)' % (self.pdgid, self.description),
-                                       self.is_generic)
+            best_width_property = best(self.widths(), self.api.pedantic, '%s (%s)' % (self.pdgid, self.description))
             return best_width_property.best_summary().get_error('GeV')
         except PdgNoDataError:
             if self.api.pedantic:
@@ -445,8 +436,7 @@ class PdgParticle(PdgData):
     def lifetime(self):
         """Lifetime of the particle in seconds."""
         try:
-            best_lifetime_property = best(self.lifetimes(), self.api.pedantic, '%s lifetime (%s)' % (self.name, self.pdgid),
-                                          self.is_generic)
+            best_lifetime_property = best(self.lifetimes(), self.api.pedantic, '%s lifetime (%s)' % (self.name, self.pdgid))
             return best_lifetime_property.best_summary().get_value('s')
         except PdgNoDataError:
             if self.api.pedantic:
@@ -459,8 +449,7 @@ class PdgParticle(PdgData):
     def lifetime_error(self):
         """Symmetric error on lifetime of particle in seconds, or None if lifetime error are asymmetric or lifetime is a limit."""
         try:
-            best_lifetime_property = best(self.lifetimes(), self.api.pedantic, '%s (%s)' % (self.pdgid, self.description),
-                                          self.is_generic)
+            best_lifetime_property = best(self.lifetimes(), self.api.pedantic, '%s (%s)' % (self.pdgid, self.description))
             err = best_lifetime_property.best_summary().get_error('s')
             if err is None:
                 err = 0.

--- a/pdg/utils.py
+++ b/pdg/utils.py
@@ -55,7 +55,7 @@ def make_id(baseid, edition=None):
         return ('%s/%s' % (baseid, edition)).upper()
 
 
-def best(properties, pedantic=False, quantity=None, is_generic=False):
+def best(properties, pedantic=False, quantity=None):
     """Return the "best" property from an iterable of properties, or raise an exception.
 
     best does (pedantic=False) or does not (pedantic=True) make assumptions about what the best property might
@@ -76,10 +76,8 @@ def best(properties, pedantic=False, quantity=None, is_generic=False):
     elif len(props_without_alternates) == 1:
         return props_without_alternates[0]
     else:
-        if is_generic or pedantic:
+        if pedantic:
             err = 'Ambiguous best property%s' % for_what
-            if is_generic:
-                err += '. This is a generic charge state; try selecting a specific charge (e.g. by setting the MC ID)'
             raise PdgAmbiguousValueError(err)
         else:
             props_best = [p for p in props_without_alternates if 'D' in p.data_flags]

--- a/tests/test_03_particle.py
+++ b/tests/test_03_particle.py
@@ -156,7 +156,6 @@ class TestData(unittest.TestCase):
 
         for self.api.pedantic in [True, False]:
             p = self.api.get_particle_by_mcid(323)
-            self.assertFalse(p.is_generic)
             self.assertEqual(len(list(p.masses())), 3)
             self.assertEqual(len(list(p.widths())), 2)
             self.assertEqual(len(list(p.lifetimes())), 0)
@@ -174,7 +173,6 @@ class TestData(unittest.TestCase):
 
         for self.api.pedantic in [True, False]:
             p = self.api.get_particle_by_mcid(-323)
-            self.assertFalse(p.is_generic)
             self.assertEqual(len(list(p.masses())), 3)
             self.assertEqual(len(list(p.widths())), 2)
             self.assertEqual(len(list(p.lifetimes())), 0)
@@ -192,7 +190,6 @@ class TestData(unittest.TestCase):
 
         for self.api.pedantic in [True, False]:
             p = self.api.get_particle_by_mcid(313)
-            self.assertFalse(p.is_generic)
             self.assertEqual(len(list(p.masses())), 2)
             self.assertEqual(len(list(p.widths())), 1)
             self.assertEqual(len(list(p.lifetimes())), 0)


### PR DESCRIPTION
We no longer have generic Particles, just generic Items. The leftover use of `PdgParticle.is_generic` (which, after the schema change, was rewritten to indicate whether a state is self-conjugate) in `utils.best` was causing, e.g., the following failure:

```
In [2]: import pdg

In [3]: api = pdg.connect()

In [4]: p = api.get_particle_by_mcid(113)

In [5]: p.mass
---------------------------------------------------------------------------
PdgAmbiguousValueError                    Traceback (most recent call last)
Cell In[5], line 1
----> 1 p.mass

File ~/physics/pdg/api/pdg/particle.py:403, in PdgParticle.mass(self)
    400 @property
    401 def mass(self):
    402     """Mass of the particle in GeV."""
--> 403     best_mass_property = best(self.masses(), self.api.pedantic, '%s mass (%s)' % (self.name, self.pdgid),
    404                               self.is_generic)
    405     return best_mass_property.best_summary().get_value('GeV')

File ~/physics/pdg/api/pdg/utils.py:83, in best(properties, pedantic, quantity, is_generic)
     81     if is_generic:
     82         err += '. This is a generic charge state; try selecting a specific charge (e.g. by setting the MC ID)'
---> 83     raise PdgAmbiguousValueError(err)
     84 else:
     85     props_best = [p for p in props_without_alternates if 'D' in p.data_flags]

PdgAmbiguousValueError: Ambiguous best property for rho(770)0 mass (M009/2023). This is a generic charge state; try selecting a specific charge (e.g. by setting the MC ID)
```

Removing `PdgParticle.is_generic` and its use in `utils.best` fixes such cases and doesn't cause any tests to fail.