### PR TITLE
SQLite file fixes

### DIFF
--- a/pdg/pdg.sqlite
+++ b/pdg/pdg.sqlite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c6e1601be3c30b1d6fda76d2423f25899f5e24fa0252e4dee08e082e1170d28c
-size 7700480
+oid sha256:48e2bebd7ca3c41a090f1fd34315bb62e7e637a80b69aa370b8dd7845dafc2ef
+size 7841792

--- a/pdg/pdg.sqlite
+++ b/pdg/pdg.sqlite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48e2bebd7ca3c41a090f1fd34315bb62e7e637a80b69aa370b8dd7845dafc2ef
+oid sha256:ad7a5e70f5c1b2d25672692aa5236218f451fd58ca3ab18648cd70358b606fb6
 size 7841792

--- a/tests/test_02_data.py
+++ b/tests/test_02_data.py
@@ -141,6 +141,8 @@ class TestData(unittest.TestCase):
         # Check fix for metadata bug in v0.0.5
         self.assertIsNotNone(self.api.get('S086DRA').best_summary())
         self.assertIsNotNone(self.api.get('S086DGS').best_summary())
+        # Check that LIMIT_TYPE is NULL instead of the empty string
+        self.assertFalse(self.api.get('S041.3').is_limit)
 
     def test_HFLAV_comment(self):
         if int(self.api.default_edition) >= 2024:

--- a/tests/test_02_data.py
+++ b/tests/test_02_data.py
@@ -144,6 +144,24 @@ class TestData(unittest.TestCase):
         # Check that LIMIT_TYPE is NULL instead of the empty string
         self.assertFalse(self.api.get('S041.3').is_limit)
 
+    def test_value_parsing(self):
+        # Check that DISPLAY_VALUE_TEXT is being parsed properly
+        # Symmetric errors:
+        self.assertEqual(round(self.api.get('S086T').value*1e12, 2), 1.52)
+        self.assertEqual(round(self.api.get('S086T').error_positive*1e15, 1), 5)
+        self.assertEqual(round(self.api.get('S086T').error_negative*1e15, 1), 5)
+        self.assertEqual(round(self.api.get('S086T').error*1e15, 1), 5)
+        # Slightly asymmetric errors:
+        self.assertEqual(round(self.api.get('S063T').value*1e12, 2), 1.64)
+        self.assertEqual(round(self.api.get('S063T').error_positive*1e13, 1), 1.8)
+        self.assertEqual(round(self.api.get('S063T').error_negative*1e13, 1), 1.7)
+        self.assertEqual(round(self.api.get('S063T').error*1e13, 2), 1.75)
+        # Very asymmetric errors:
+        self.assertEqual(round(self.api.get('S041P63').value*1e3, 1), 10.2)
+        self.assertEqual(round(self.api.get('S041P63').error_positive*1e3, 1), 3.2)
+        self.assertEqual(round(self.api.get('S041P63').error_negative*1e3, 1), 6.9)
+        self.assertIsNone(self.api.get('S041P63').error)
+
     def test_HFLAV_comment(self):
         if int(self.api.default_edition) >= 2024:
             self.assertEqual(self.api.get('S042T').comment,

--- a/tests/test_03_particle.py
+++ b/tests/test_03_particle.py
@@ -86,6 +86,14 @@ class TestData(unittest.TestCase):
         self.assertEqual(round(self.api.get('s008/2022')[0].mass,9), 0.139570391)
         self.assertEqual(round(self.api.get('s008/2022')[0].mass_error,16), 1.820071604e-07)
 
+    def test_best_masses(self):
+        self.assertEqual(round(self.api.get_particle_by_name('p').mass, 3), 0.938)
+        self.assertEqual(round(self.api.get_particle_by_name('pi+').mass, 3), 0.140)
+        self.assertEqual(round(self.api.get_particle_by_name('e-').mass, 6), 0.000511)
+        self.assertEqual(round(self.api.get_particle_by_name('tbar').mass, 1), 172.6)
+        self.assertEqual(round(self.api.get_particle_by_name('B+').mass, 2), 5.28)
+        self.assertEqual(round(self.api.get_particle_by_name('Z').mass, 1), 91.2)
+
     def test_flags(self):
         self.assertEqual(self.api.get('S008')[0].is_boson, False)
         self.assertEqual(self.api.get('S008')[0].is_quark, False)


### PR DESCRIPTION
SQLite file regenerated after the following fixes in postgresql:

- No more empty strings where NULL is required (fixing #13; previously manually patched in the SQLite file)
- Correct parsing of display_values with uncertainties and exponents in "parenthesis-free" shorthand (fixing #15)

Corresponding tests are included.

The last commit here is a [patch](https://gist.github.com/mjkramer/2c27b866e602cfec21fa046d76f89c76) to the descriptions of 117 PDGIDs, based diffing against the newly-generated "from scratch" tables. Almost all cases are removals of extraneous arrows ("-->") in the descriptions. The handful of exceptions are corrections to the signs of pions in descriptions of decays, e.g. M240.1 and M240R01.