### PR TITLE
Add type annotations

### DIFF
--- a/docs/sphinx-requirements.txt
+++ b/docs/sphinx-requirements.txt
@@ -4,4 +4,4 @@ myst-parser
 
 # The following is required to automatically document package pdg
 SQLAlchemy<2.0
-
+typing_extensions

--- a/pdg/__init__.py
+++ b/pdg/__init__.py
@@ -9,6 +9,8 @@ For documentation see https://pdgapi.lbl.gov/doc.
 For general information about PDG and the Review of Particle Physics
 please visit https://pdg.lbl.gov.
 """
+from pdg.api import PdgApi
+
 __author__ = 'Particle Data Group'
 __version__ = '0.2.3'
 
@@ -23,7 +25,7 @@ SQLITE_FILENAME = 'pdg.sqlite'      # Default SQLite database file used by this 
 MIN_SCHEMA_VERSION = 0.3            # Minimum schema version required by this version of the API
 
 
-def connect(database_url=None, pedantic=False):
+def connect(database_url: None=None, pedantic: bool=False) -> PdgApi:
     """Connect to PDG database and return configured PDG API object."""
     if database_url is None:
         api = PdgApi('sqlite:///%s' % os.path.join(os.path.dirname(__file__), SQLITE_FILENAME), pedantic)

--- a/pdg/__init__.py
+++ b/pdg/__init__.py
@@ -16,6 +16,8 @@ __version__ = '0.2.3'
 
 
 import os
+from typing import Optional
+
 from pdg.api import PdgApi
 from pdg.errors import PdgApiError
 
@@ -25,7 +27,7 @@ SQLITE_FILENAME = 'pdg.sqlite'      # Default SQLite database file used by this 
 MIN_SCHEMA_VERSION = 0.3            # Minimum schema version required by this version of the API
 
 
-def connect(database_url: None=None, pedantic: bool=False) -> PdgApi:
+def connect(database_url: Optional[str]=None, pedantic: bool=False) -> PdgApi:
     """Connect to PDG database and return configured PDG API object."""
     if database_url is None:
         api = PdgApi('sqlite:///%s' % os.path.join(os.path.dirname(__file__), SQLITE_FILENAME), pedantic)

--- a/pdg/api.py
+++ b/pdg/api.py
@@ -12,7 +12,7 @@ from pdg.utils import parse_id
 from pdg.data import PdgData, PdgProperty, PdgMass, PdgWidth, PdgLifetime, PdgText
 from pdg.decay import PdgBranchingFraction, PdgBranchingRatio, PdgItem
 from pdg.particle import PdgParticle, PdgParticleList
-from typing import Iterator, List, Optional
+from typing import Iterator, List, Optional, cast
 
 
 # Map PDG data type codes to corresponding classes
@@ -79,7 +79,7 @@ class PdgApi:
         pdginfo_table = self.db.tables['pdginfo']
         query = select(pdginfo_table.c.value).where(pdginfo_table.c.name == bindparam('key'))
         with self.engine.connect() as conn:
-            return conn.execute(query, {'key': key}).scalar()
+            return cast(str, conn.execute(query, {'key': key}).scalar())
 
     def info_keys(self) -> List[str]:
         """Return list of all metadata keys."""
@@ -269,25 +269,29 @@ class PdgApi:
         When as_text is True (default), the list is returned as a formatted string suitable for printing.
         Otherwise, a list of dict is returned, where each dict describes a possible key value.
         """
-        keys = []
-        if as_text:
-            keys.append('Key value     Description')
-            keys.append('-'*60)
         pdgdoc_table = self.db.tables['pdgdoc']
         query = select(pdgdoc_table)
         query = query.where(pdgdoc_table.c.table_name == 'PDGID')
         query = query.where(pdgdoc_table.c.column_name == 'DATA_TYPE')
         query.order_by(pdgdoc_table.c.indicator, pdgdoc_table.c.value)
+
+        if as_text:
+            lines: list[str] = []
+            lines.append('Key value     Description')
+            lines.append('-'*60)
+        else:
+            mappings: list[RowMapping] = []
+
         with self.engine.connect() as conn:
             for item in conn.execute(query):
                 if as_text:
-                    keys.append('  %-8s    %s' % (item.value, item.description))
+                    lines.append('  %-8s    %s' % (item.value, item.description))
                 else:
-                    keys.append(item._mapping)
+                    mappings.append(item._mapping)
         if as_text:
-            return '\n'.join(keys)
+            return '\n'.join(lines)
         else:
-            return keys
+            return mappings
 
     def doc_value_type_keys(self, as_text: bool=True) -> str | List[RowMapping]:
         """Get list of summary value type keys.
@@ -299,22 +303,26 @@ class PdgApi:
         When as_text is True (default), the list is returned as a formatted string suitable for printing.
         Otherwise, a list of dict is returned, where each dict describes a possible key value.
         """
-        keys = []
-        if as_text:
-            keys.append('Key value   Indicator            Description')
-            keys.append('-'*60)
         pdgdoc_table = self.db.tables['pdgdoc']
         query = select(pdgdoc_table)
         query = query.where(pdgdoc_table.c.table_name == 'PDGDATA')
         query = query.where(pdgdoc_table.c.column_name == 'VALUE_TYPE')
         query.order_by(pdgdoc_table.c.indicator, pdgdoc_table.c.value)
+
+        if as_text:
+            lines: list[str] = []
+            lines.append('Key value   Indicator            Description')
+            lines.append('-'*60)
+        else:
+            mappings: list[RowMapping] = []
+
         with self.engine.connect() as conn:
             for item in conn.execute(query):
                 if as_text:
-                    keys.append('  %-8s  %-20s  %s' % (item.value, item.indicator, item.description))
+                    lines.append('  %-8s  %-20s  %s' % (item.value, item.indicator, item.description))
                 else:
-                    keys.append(item._mapping)
+                    mappings.append(item._mapping)
         if as_text:
-            return '\n'.join(keys)
+            return '\n'.join(lines)
         else:
-            return keys
+            return mappings

--- a/pdg/api.py
+++ b/pdg/api.py
@@ -8,9 +8,10 @@ from sqlalchemy import func, select, bindparam, distinct, desc
 import pdg
 from pdg.errors import PdgAmbiguousValueError, PdgInvalidPdgIdError, PdgNoDataError
 from pdg.utils import parse_id
-from pdg.data import PdgProperty, PdgMass, PdgWidth, PdgLifetime, PdgText
+from pdg.data import PdgData, PdgProperty, PdgMass, PdgWidth, PdgLifetime, PdgText
 from pdg.decay import PdgBranchingFraction, PdgBranchingRatio, PdgItem
 from pdg.particle import PdgParticle, PdgParticleList
+from typing import List, Optional, Union
 
 
 # Map PDG data type codes to corresponding classes
@@ -38,7 +39,7 @@ DATA_TYPE_MAP = {
 
 class PdgApi:
 
-    def __init__(self, database_url, pedantic=False):
+    def __init__(self, database_url: str, pedantic: bool=False):
         """Initialize PDG API.
 
         database_url is the URL of the PDG database to connect to. The default database is the SQLite file
@@ -60,7 +61,7 @@ class PdgApi:
             self.logger.addHandler(logging.StreamHandler())
             self.logger.propagate = False
 
-    def __str__(self):
+    def __str__(self) -> str:
         s = ['%s Review of Particle Physics, data release %s, API version %s' % (self.info('edition'),
                                                                                  self.info('data_release_timestamp'),
                                                                                  pdg.__version__),
@@ -70,14 +71,14 @@ class PdgApi:
              ]
         return '\n'.join(s)
 
-    def info(self, key):
+    def info(self, key: str) -> str:
         """Return metadata info specified by key."""
         pdginfo_table = self.db.tables['pdginfo']
         query = select(pdginfo_table.c.value).where(pdginfo_table.c.name == bindparam('key'))
         with self.engine.connect() as conn:
             return conn.execute(query, {'key': key}).scalar()
 
-    def info_keys(self):
+    def info_keys(self) -> List[str]:
         """Return list of all metadata keys."""
         pdginfo_table = self.db.tables['pdginfo']
         query = select(pdginfo_table.c.name)
@@ -85,7 +86,7 @@ class PdgApi:
             return [k[0] for k in conn.execute(query).fetchall()]
 
     @property
-    def editions(self):
+    def editions(self) -> List[str]:
         """List of all editions of the Review for which the database has data."""
         pdgdata_table = self.db.tables['pdgdata']
         query = select(distinct(pdgdata_table.c.edition)).order_by(desc(pdgdata_table.c.edition))
@@ -93,11 +94,11 @@ class PdgApi:
             return [e[0] for e in conn.execute(query).fetchall()]
 
     @property
-    def default_edition(self):
+    def default_edition(self) -> str:
         """Return the default edition for this database."""
         return self.info('edition')
 
-    def get(self, pdgid, edition=None):
+    def get(self, pdgid: str, edition: Optional[str]=None) -> PdgData:
         """Return PdgData object for given PDG Identifier.
 
         The get method checks what data the PDG Identifier describes and returns an
@@ -146,7 +147,7 @@ class PdgApi:
                     cls = PdgProperty
                 yield cls(self, item.pdgid, edition)
 
-    def _get_particles_by_name(self, name, case_sensitive=True, edition=None, unique=True):
+    def _get_particles_by_name(self, name: str, case_sensitive: bool=True, edition: None=None, unique: bool=True) -> Union[PdgParticle, List[PdgParticle]]:
         """Helper function used by get_particle(s)_by_name. Returns a
         PdgParticle (list thereof) if unique is True (False). Raises a
         PdgAmbiguousValueError if more than one PdgItem exists with the given
@@ -170,7 +171,7 @@ class PdgApi:
         else:
             raise PdgAmbiguousValueError('More than one PDGITEM named %s', name)
 
-    def get_particle_by_name(self, name, case_sensitive=True, edition=None):
+    def get_particle_by_name(self, name: str, case_sensitive: bool=True, edition: None=None) -> PdgParticle:
         """Get particle by its name.
 
         case_sensitive can be set False to indicate that the particle name should be
@@ -181,7 +182,7 @@ class PdgApi:
         return self._get_particles_by_name(name, case_sensitive=case_sensitive,
                                            edition=edition, unique=True)
 
-    def get_particles_by_name(self, name, case_sensitive=True, edition=None):
+    def get_particles_by_name(self, name: str, case_sensitive: bool=True, edition: None=None) -> List[PdgParticle]:
         """Get all particles for a (possibly generic) name.
 
         case_sensitive can be set False to indicate that the particle name should be
@@ -192,7 +193,7 @@ class PdgApi:
         return self._get_particles_by_name(name, case_sensitive=case_sensitive,
                                            edition=edition, unique=False)
 
-    def get_particle_by_mcid(self, mcid, edition=None):
+    def get_particle_by_mcid(self, mcid: int, edition: None=None) -> PdgParticle:
         """Get particle by its MC ID.
 
         edition can be set to a specific edition, from which data should later be retrieved.
@@ -209,7 +210,7 @@ class PdgApi:
         else:
             raise ValueError('MC number %s matches %i particles with PDG Identifiers %s' % (mcid, len(matches), matches))
 
-    def get_particles(self, edition=None):
+    def get_particles(self, edition: None=None):
         """Return iterator over all particles.
 
         edition can be set to a specific edition, from which data should later be retrieved.

--- a/pdg/api.py
+++ b/pdg/api.py
@@ -275,12 +275,12 @@ class PdgApi:
         query = query.where(pdgdoc_table.c.column_name == 'DATA_TYPE')
         query.order_by(pdgdoc_table.c.indicator, pdgdoc_table.c.value)
 
+        lines: list[str] = []
+        mappings: list[RowMapping] = []
+
         if as_text:
-            lines: list[str] = []
             lines.append('Key value     Description')
             lines.append('-'*60)
-        else:
-            mappings: list[RowMapping] = []
 
         with self.engine.connect() as conn:
             for item in conn.execute(query):
@@ -309,12 +309,12 @@ class PdgApi:
         query = query.where(pdgdoc_table.c.column_name == 'VALUE_TYPE')
         query.order_by(pdgdoc_table.c.indicator, pdgdoc_table.c.value)
 
+        lines: list[str] = []
+        mappings: list[RowMapping] = []
+
         if as_text:
-            lines: list[str] = []
             lines.append('Key value   Indicator            Description')
             lines.append('-'*60)
-        else:
-            mappings: list[RowMapping] = []
 
         with self.engine.connect() as conn:
             for item in conn.execute(query):

--- a/pdg/api.py
+++ b/pdg/api.py
@@ -12,7 +12,7 @@ from pdg.utils import parse_id
 from pdg.data import PdgData, PdgProperty, PdgMass, PdgWidth, PdgLifetime, PdgText
 from pdg.decay import PdgBranchingFraction, PdgBranchingRatio, PdgItem
 from pdg.particle import PdgParticle, PdgParticleList
-from typing import Iterator, List, Optional, cast
+from typing import Iterator, Optional, cast
 
 
 # Map PDG data type codes to corresponding classes
@@ -81,7 +81,7 @@ class PdgApi:
         with self.engine.connect() as conn:
             return cast(str, conn.execute(query, {'key': key}).scalar())
 
-    def info_keys(self) -> List[str]:
+    def info_keys(self) -> list[str]:
         """Return list of all metadata keys."""
         pdginfo_table = self.db.tables['pdginfo']
         query = select(pdginfo_table.c.name)
@@ -89,7 +89,7 @@ class PdgApi:
             return [k[0] for k in conn.execute(query).fetchall()]
 
     @property
-    def editions(self) -> List[str]:
+    def editions(self) -> list[str]:
         """List of all editions of the Review for which the database has data."""
         pdgdata_table = self.db.tables['pdgdata']
         query = select(distinct(pdgdata_table.c.edition)).order_by(desc(pdgdata_table.c.edition))
@@ -131,7 +131,7 @@ class PdgApi:
             cls = PdgProperty
         return cls(self, baseid, edition)
 
-    def get_all(self, data_type_key=None, edition=None):
+    def get_all(self, data_type_key=None, edition=None) -> Iterator[PdgData]:
         """Return iterator over all PDG Identifiers / quantities. Returns PdgProperties or derived classes.
 
         If data_type_key is set, only quantities of the given type are returned.
@@ -154,7 +154,7 @@ class PdgApi:
 
     def _get_particles_by_name(self, name: str, case_sensitive: bool=True,
                                edition: Optional[str]=None, unique: bool=True) \
-            -> PdgParticle | List[PdgParticle]:
+            -> PdgParticle | list[PdgParticle]:
         """Helper function used by get_particle(s)_by_name. Returns a
         PdgParticle (list thereof) if unique is True (False). Raises a
         PdgAmbiguousValueError if more than one PdgItem exists with the given
@@ -258,7 +258,7 @@ class PdgApi:
             except AttributeError:
                 raise PdgNoDataError('No documentation for value %s in table %s.%s' % (key, table_name, column_name))
 
-    def doc_data_type_keys(self, as_text: bool=True) -> str | List[RowMapping]:
+    def doc_data_type_keys(self, as_text: bool=True) -> str | list[RowMapping]:
         """Get list of data type keys.
 
         The PDG API uses a data type key as part of the PDG Identifier metadata to denote the kind of information
@@ -293,7 +293,7 @@ class PdgApi:
         else:
             return mappings
 
-    def doc_value_type_keys(self, as_text: bool=True) -> str | List[RowMapping]:
+    def doc_value_type_keys(self, as_text: bool=True) -> str | list[RowMapping]:
         """Get list of summary value type keys.
 
         For each summary value, the value type key specifies how this value was derived, e.g. whether it is the

--- a/pdg/api.py
+++ b/pdg/api.py
@@ -5,13 +5,14 @@ PDG API top-level class.
 import logging
 import sqlalchemy
 from sqlalchemy import func, select, bindparam, distinct, desc
+from sqlalchemy.engine.row import RowMapping
 import pdg
 from pdg.errors import PdgAmbiguousValueError, PdgInvalidPdgIdError, PdgNoDataError
 from pdg.utils import parse_id
 from pdg.data import PdgData, PdgProperty, PdgMass, PdgWidth, PdgLifetime, PdgText
 from pdg.decay import PdgBranchingFraction, PdgBranchingRatio, PdgItem
 from pdg.particle import PdgParticle, PdgParticleList
-from typing import List, Optional, Union
+from typing import Iterator, List, Optional
 
 
 # Map PDG data type codes to corresponding classes
@@ -60,6 +61,8 @@ class PdgApi:
         if not self.logger.handlers:
             self.logger.addHandler(logging.StreamHandler())
             self.logger.propagate = False
+
+        self._subdecay_warned = False # see PdgBranchingFraction.subdecays()
 
     def __str__(self) -> str:
         s = ['%s Review of Particle Physics, data release %s, API version %s' % (self.info('edition'),
@@ -117,7 +120,9 @@ class PdgApi:
         try:
             query = select(pdgid_table.c.data_type).where(pdgid_table.c.pdgid == bindparam('pdgid'))
             with self.engine.connect() as conn:
-                data_type = conn.execute(query, {'pdgid': baseid}).fetchone()[0]
+                row = conn.execute(query, {'pdgid': baseid}).fetchone()
+                assert row is not None
+                data_type = row[0]
         except Exception:
             raise PdgInvalidPdgIdError('PDG Identifier %s not found' % pdgid)
         try:
@@ -147,7 +152,9 @@ class PdgApi:
                     cls = PdgProperty
                 yield cls(self, item.pdgid, edition)
 
-    def _get_particles_by_name(self, name: str, case_sensitive: bool=True, edition: None=None, unique: bool=True) -> Union[PdgParticle, List[PdgParticle]]:
+    def _get_particles_by_name(self, name: str, case_sensitive: bool=True,
+                               edition: Optional[str]=None, unique: bool=True) \
+            -> PdgParticle | List[PdgParticle]:
         """Helper function used by get_particle(s)_by_name. Returns a
         PdgParticle (list thereof) if unique is True (False). Raises a
         PdgAmbiguousValueError if more than one PdgItem exists with the given
@@ -171,7 +178,8 @@ class PdgApi:
         else:
             raise PdgAmbiguousValueError('More than one PDGITEM named %s', name)
 
-    def get_particle_by_name(self, name: str, case_sensitive: bool=True, edition: None=None) -> PdgParticle:
+    def get_particle_by_name(self, name: str, case_sensitive: bool=True,
+                             edition: Optional[str]=None) -> PdgParticle:
         """Get particle by its name.
 
         case_sensitive can be set False to indicate that the particle name should be
@@ -179,10 +187,13 @@ class PdgApi:
 
         edition can be set to a specific edition, from which data should later be retrieved.
         """
-        return self._get_particles_by_name(name, case_sensitive=case_sensitive,
-                                           edition=edition, unique=True)
+        particle =  self._get_particles_by_name(name, case_sensitive=case_sensitive,
+                                                edition=edition, unique=True)
+        assert isinstance(particle, PdgParticle)
+        return particle
 
-    def get_particles_by_name(self, name: str, case_sensitive: bool=True, edition: None=None) -> List[PdgParticle]:
+    def get_particles_by_name(self, name: str, case_sensitive: bool=True,
+                              edition: Optional[str]=None) -> list[PdgParticle]:
         """Get all particles for a (possibly generic) name.
 
         case_sensitive can be set False to indicate that the particle name should be
@@ -190,10 +201,13 @@ class PdgApi:
 
         edition can be set to a specific edition, from which data should later be retrieved.
         """
-        return self._get_particles_by_name(name, case_sensitive=case_sensitive,
-                                           edition=edition, unique=False)
+        particles =  self._get_particles_by_name(name, case_sensitive=case_sensitive,
+                                                 edition=edition, unique=False)
+        assert not isinstance(particles, PdgParticle)
+        return particles
 
-    def get_particle_by_mcid(self, mcid: int, edition: None=None) -> PdgParticle:
+    def get_particle_by_mcid(self, mcid: int, edition: Optional[str]=None) \
+            -> PdgParticle:
         """Get particle by its MC ID.
 
         edition can be set to a specific edition, from which data should later be retrieved.
@@ -210,7 +224,7 @@ class PdgApi:
         else:
             raise ValueError('MC number %s matches %i particles with PDG Identifiers %s' % (mcid, len(matches), matches))
 
-    def get_particles(self, edition: None=None):
+    def get_particles(self, edition: Optional[str]=None) -> Iterator[PdgParticleList]:
         """Return iterator over all particles.
 
         edition can be set to a specific edition, from which data should later be retrieved.
@@ -224,10 +238,11 @@ class PdgApi:
             for item in conn.execute(query):
                 yield PdgParticleList(self, item.pdgid, edition)
 
-    def get_canonical_name(self, name):
+    def get_canonical_name(self, name: str) -> str:
         return self.get_particle_by_name(name).name
 
-    def doc_key_value(self, table_name, column_name, key):
+    def doc_key_value(self, table_name: str, column_name: str, key: str) \
+            -> RowMapping:
         """Get documentation on the meaning of key values or flags used in the PDG API."""
         pdgdoc_table = self.db.tables['pdgdoc']
         query = select(pdgdoc_table)
@@ -236,12 +251,14 @@ class PdgApi:
         query = query.where(pdgdoc_table.c.value == bindparam('value'))
         with self.engine.connect() as conn:
             try:
-                return conn.execute(query, {'table_name': table_name, 'column_name': column_name, 'value': key}).\
-                    fetchone()._mapping
+                row = conn.execute(query, {'table_name': table_name, 'column_name': column_name, 'value': key}).\
+                    fetchone()
+                assert row is not None
+                return row._mapping
             except AttributeError:
                 raise PdgNoDataError('No documentation for value %s in table %s.%s' % (key, table_name, column_name))
 
-    def doc_data_type_keys(self, as_text=True):
+    def doc_data_type_keys(self, as_text: bool=True) -> str | List[RowMapping]:
         """Get list of data type keys.
 
         The PDG API uses a data type key as part of the PDG Identifier metadata to denote the kind of information
@@ -272,7 +289,7 @@ class PdgApi:
         else:
             return keys
 
-    def doc_value_type_keys(self, as_text=True):
+    def doc_value_type_keys(self, as_text: bool=True) -> str | List[RowMapping]:
         """Get list of summary value type keys.
 
         For each summary value, the value type key specifies how this value was derived, e.g. whether it is the

--- a/pdg/data.py
+++ b/pdg/data.py
@@ -17,7 +17,7 @@ from pdg.units import UNIT_CONVERSION_FACTORS, convert
 from pdg.errors import PdgApiError, PdgInvalidPdgIdError, PdgAmbiguousValueError, PdgNoDataError
 from pdg.measurement import PdgMeasurement
 from sqlalchemy.engine.row import RowMapping
-from typing import TYPE_CHECKING, List, Optional, cast
+from typing import TYPE_CHECKING, Iterator, Optional, cast
 
 if TYPE_CHECKING:
     from pdg.api import PdgApi
@@ -27,13 +27,13 @@ if TYPE_CHECKING:
 class PdgSummaryValue(dict):
     """Container for a single value from the Summary Tables."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         indicator = self.value_type
         if not indicator:
             indicator = '[key = %s]' % self.value_type_key
         return '%-20s %-20s  %s' % (self.value_text, indicator, self.comment if self.comment else '')
 
-    def pprint(self):
+    def pprint(self) -> None:
         """Print all data in this PdgSummaryValue object in a nice format (for debugging)."""
         pprint.pprint(self)
 
@@ -51,7 +51,7 @@ class PdgSummaryValue(dict):
             except TypeError:
                 return None
 
-    def get_error_positive(self, units=None):
+    def get_error_positive(self, units: Optional[str]=None) -> float:
         """Return positive error after conversion into units specified by parameter units (string).
 
         If units are not specified, the positive error is returned without conversion in the default
@@ -62,7 +62,7 @@ class PdgSummaryValue(dict):
         else:
             return convert(self['error_positive'], self['unit_text'], units)
 
-    def get_error_negative(self, units=None):
+    def get_error_negative(self, units: Optional[str]=None) -> float:
         """Return negative error after conversion into units specified by parameter units (string).
 
         If units are not specified, the negative error is returned without conversion in the default
@@ -90,24 +90,24 @@ class PdgSummaryValue(dict):
             return None
 
     @property
-    def pdgid(self):
+    def pdgid(self) -> str:
         """PDG Identifier of quantity for which value is given."""
         return self['pdgid']
 
     @property
-    def description(self):
+    def description(self) -> str:
         """Description of quantity for which value is given"""
         return self['description']
 
     @property
-    def value_type_key(self):
+    def value_type_key(self) -> str:
         """Type of value, given by its key.
 
         See PdgApi.doc_value_type_keys() for the meaning of the different value type keys."""
         return self['value_type']
 
     @property
-    def value_type(self):
+    def value_type(self) -> str:
         """Type of value, given as the PDG indicator string."""
         if self.value_type_key in ('AC', 'D', 'E'):
             return 'OUR AVERAGE'
@@ -128,7 +128,7 @@ class PdgSummaryValue(dict):
         return self['in_summary_table']
 
     @property
-    def confidence_level(self):
+    def confidence_level(self) -> Optional[float]:
         """Confidence level for limits, None otherwise."""
         return self['confidence_level']
 
@@ -138,12 +138,12 @@ class PdgSummaryValue(dict):
         return self['confidence_level'] is not None or self['limit_type'] is not None
 
     @property
-    def is_upper_limit(self):
+    def is_upper_limit(self) -> bool:
         """True if value is an upper limit."""
         return self['limit_type'] == 'U'
 
     @property
-    def is_lower_limit(self):
+    def is_lower_limit(self) -> bool:
         """True if value is an lower limit."""
         return self['limit_type'] == 'L'
 
@@ -168,7 +168,6 @@ class PdgSummaryValue(dict):
     @property
     def error_negative(self) -> float:
         """Numerical value of negative error in units given by property units."""
-
         return self['error_negative']
 
     @property
@@ -180,12 +179,12 @@ class PdgSummaryValue(dict):
         return self.get_error()
 
     @property
-    def scale_factor(self):
+    def scale_factor(self) -> float:
         """PDG error scale factor that was applied to error_positive and error_negative."""
         return self['scale_factor'] or 1.0
 
     @property
-    def units(self):
+    def units(self) -> str:
         """Units (in plain text format) used by value, error_positive,
         error_negative, and display_value_text."""
         return self['unit_text']
@@ -197,7 +196,7 @@ class PdgSummaryValue(dict):
     #     return self['unit_tex']
 
     @property
-    def value_text(self):
+    def value_text(self) -> str:
         """Value and uncertainty (in plain text format) in units given by
            property units, including the power of ten, if applicable
            (see display_power_of_ten)"""
@@ -211,7 +210,7 @@ class PdgSummaryValue(dict):
     #     return self['value_tex']
 
     @property
-    def display_value_text(self):
+    def display_value_text(self) -> str:
         """Value and uncertainty in plain text format as displayed in
            Listings tables. Does not include any power of ten or percent sign.
            Must be combined with the display_power_of_ten property in order
@@ -219,12 +218,12 @@ class PdgSummaryValue(dict):
         return self['display_value_text']
 
     @property
-    def display_power_of_ten(self):
+    def display_power_of_ten(self) -> int:
         """Unit multiplier (as power of ten) as used for display in Listings."""
         return self['display_power_of_ten']
 
     @property
-    def display_in_percent(self):
+    def display_in_percent(self) -> bool:
         """True if value is rendered in percent for display in Listings.
            Implies that display_power_of_ten is -2."""
         return self['display_in_percent']
@@ -233,7 +232,7 @@ class PdgSummaryValue(dict):
 class PdgConvertedValue(PdgSummaryValue):
     """A PdgSummaryValue class for storing summary values after unit conversion."""
 
-    def __init__(self, value, to_units):
+    def __init__(self, value: PdgSummaryValue, to_units: str):
         """Instantiate a copy of PdgSummaryValue value with new units to_unit."""
         super(PdgConvertedValue, self).__init__(value)
         self.original_units = value.units
@@ -286,10 +285,10 @@ class PdgData(object):
         self.pdgid = make_id(self.baseid, self._edition)
         self.cache: dict[str, RowMapping | list[RowMapping] | list[PdgSummaryValue]] = {}
 
-    def __str__(self):
+    def __str__(self) -> str:
         return 'Data for PDG Identifier %s: %s' % (self.pdgid, self.description)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         extra = self._repr_extra()
         if extra:
             extra = ', ' + extra
@@ -317,7 +316,7 @@ class PdgData(object):
         assert isinstance(self.cache['pdgid'], RowMapping)
         return self.cache['pdgid']
 
-    def _get_summary_values(self) -> List[PdgSummaryValue]:
+    def _get_summary_values(self) -> list[PdgSummaryValue]:
         """Get all summary data values."""
         if 'summary' not in self.cache:
             pdgid_table = self.api.db.tables['pdgid']
@@ -333,14 +332,16 @@ class PdgData(object):
             self.cache['summary'] = summary
         return cast(list[PdgSummaryValue], self.cache['summary'])
 
-    def _count_data_entries(self, pdgid, edition):
+    def _count_data_entries(self, pdgid: str, edition: str) -> int:
         """Count number of data entries for a given PDG identifier and edition."""
         pdgdata_table = self.api.db.tables['pdgdata']
         query = select(func.count("*")).select_from(pdgdata_table)
         query = query.where(pdgdata_table.c.pdgid == bindparam('pdgid'))
         query = query.where(pdgdata_table.c.edition == bindparam('edition'))
         with self.api.engine.connect() as conn:
-            return conn.execute(query, {'pdgid': pdgid.upper(), 'edition': edition}).scalar()
+            count = conn.execute(query, {'pdgid': pdgid.upper(), 'edition': edition}).scalar()
+            assert count is not None
+            return count
 
     def get_parent_pdgid(self, include_edition: bool=True) -> str:
         """Return PDG Identifier of this property's parent. In most cases, this
@@ -373,7 +374,7 @@ class PdgData(object):
             raise PdgAmbiguousValueError(err)
         return ps[0]
 
-    def get_children(self, recurse=False):
+    def get_children(self, recurse: bool=False) -> Iterator['PdgData']:
         pdgid_table = self.api.db.tables['pdgid']
         ## NOTE: Querying on IDs doesn't work because the `parent_id` seems off
         # query = select(pdgid_table.c.pdgid) \
@@ -393,12 +394,12 @@ class PdgData(object):
                     yield c
 
     @property
-    def edition(self):
+    def edition(self) -> Optional[str]:
         """Year of edition for which data is requested."""
         return self._edition
 
     @edition.setter
-    def edition(self, edition):
+    def edition(self, edition: str) -> None:
         """Set year of edition used for retrieving data (invalidates cache)."""
         self._edition = edition
         self.pdgid = make_id(self.baseid, self._edition)
@@ -439,7 +440,7 @@ class PdgData(object):
 class PdgProperty(PdgData):
     """Base class for containers for data containers for particle properties."""
 
-    def summary_values(self, summary_table_only: bool=False) -> List[PdgSummaryValue]:
+    def summary_values(self, summary_table_only: bool=False) -> list[PdgSummaryValue]:
         """Return list of summary values for this quantity.
 
         By default, all summary values are included, even if they are only shown in the
@@ -451,7 +452,7 @@ class PdgProperty(PdgData):
         else:
             return self._get_summary_values()
 
-    def n_summary_table_values(self):
+    def n_summary_table_values(self) -> int:
         """Return number of summary values in Summary Table for this quantity."""
         return len(self.summary_values(summary_table_only=True))
 
@@ -490,14 +491,14 @@ class PdgProperty(PdgData):
                 else:
                     return summaries[0]
 
-    def has_best_summary(self, summary_table_only=False):
+    def has_best_summary(self, summary_table_only: bool=False) -> bool:
         """Return True if there is a single PDG "best" value (see best_value() for definition)."""
         try:
             return self.best_summary(summary_table_only) is not None
         except PdgAmbiguousValueError:
             return False
 
-    def get_measurements(self):
+    def get_measurements(self) -> Iterator[PdgMeasurement]:
         """Return all of the measurements associated with this property."""
         pdgmsmt_table = self.api.db.tables['pdgmeasurement']
         query = select(pdgmsmt_table.c.id)
@@ -518,7 +519,7 @@ class PdgProperty(PdgData):
             return row[0]
 
     @property
-    def confidence_level(self):
+    def confidence_level(self) -> Optional[float]:
         """Shortcut for best_summary().confidence_level."""
         best = self.best_summary()
         assert best is not None
@@ -560,14 +561,14 @@ class PdgProperty(PdgData):
         return best.error_negative
 
     @property
-    def scale_factor(self):
+    def scale_factor(self) -> float:
         """Shortcut for best_summary().scale_factor."""
         best = self.best_summary()
         assert best is not None
         return best.scale_factor
 
     @property
-    def units(self):
+    def units(self) -> str:
         """Shortcut for best_summary().units."""
         best = self.best_summary()
         assert best is not None
@@ -581,14 +582,14 @@ class PdgProperty(PdgData):
         return best.comment
 
     @property
-    def value_text(self):
+    def value_text(self) -> str:
         """Shortcut for best_summary().value_text."""
         best = self.best_summary()
         assert best is not None
         return best.value_text
 
     @property
-    def display_value_text(self):
+    def display_value_text(self) -> str:
         """Shortcut for best_summary().display_value_text."""
         best = self.best_summary()
         assert best is not None

--- a/pdg/data.py
+++ b/pdg/data.py
@@ -16,6 +16,11 @@ from pdg.utils import parse_id, make_id
 from pdg.units import UNIT_CONVERSION_FACTORS, convert
 from pdg.errors import PdgApiError, PdgInvalidPdgIdError, PdgAmbiguousValueError, PdgNoDataError
 from pdg.measurement import PdgMeasurement
+from sqlalchemy.engine.row import RowMapping
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from pdg.api import PdgApi
 
 
 class PdgSummaryValue(dict):
@@ -31,7 +36,7 @@ class PdgSummaryValue(dict):
         """Print all data in this PdgSummaryValue object in a nice format (for debugging)."""
         pprint.pprint(self)
 
-    def get_value(self, units=None):
+    def get_value(self, units: Optional[str]=None) -> float:
         """Return value after conversion into units specified by parameter units (string).
 
         If units are not specified, the value is returned without conversion in the default units for this quantity.
@@ -67,7 +72,7 @@ class PdgSummaryValue(dict):
         else:
             return convert(self['error_negative'], self['unit_text'], units)
 
-    def get_error(self, units=None):
+    def get_error(self, units: Optional[str]=None) -> float:
         """Symmetric error or None, in units specified by parameter units (string).
 
         Returns symmetric error as average of positive and negative errors if they differ by less than 10% of
@@ -117,7 +122,7 @@ class PdgSummaryValue(dict):
             return ''
 
     @property
-    def in_summary_table(self):
+    def in_summary_table(self) -> bool:
         """True if value is included in Summary Table."""
         return self['in_summary_table']
 
@@ -127,7 +132,7 @@ class PdgSummaryValue(dict):
         return self['confidence_level']
 
     @property
-    def is_limit(self):
+    def is_limit(self) -> bool:
         """True if value is a limit."""
         return self['confidence_level'] is not None or self['limit_type'] is not None
 
@@ -142,12 +147,12 @@ class PdgSummaryValue(dict):
         return self['limit_type'] == 'L'
 
     @property
-    def comment(self):
+    def comment(self) -> str:
         """Details for or comments on this value."""
         return self['comment']
 
     @property
-    def value(self):
+    def value(self) -> float:
         """Numerical value in units given by property units.
 
         Check properties is_limit, is_lower_limit and is_upper_limit to determine if value is a central value or limit.
@@ -155,18 +160,18 @@ class PdgSummaryValue(dict):
         return self['value']
 
     @property
-    def error_positive(self):
+    def error_positive(self) -> float:
         """Numerical value of positive error in units given by property units."""
         return self['error_positive']
 
     @property
-    def error_negative(self):
+    def error_negative(self) -> float:
         """Numerical value of negative error in units given by property units."""
 
         return self['error_negative']
 
     @property
-    def error(self):
+    def error(self) -> Optional[float]:
         """Symmetric error or None.
 
         Returns symmetric error as average of positive and negative errors if they differ by less than 10% of
@@ -258,7 +263,7 @@ class PdgData(object):
     and is the base class for all PDG data container classes.
     """
 
-    def __init__(self, api, pdgid, edition=None):
+    def __init__(self, api: 'PdgApi', pdgid: str, edition: Optional[str]=None):
         """Instantiate a PdgData object for the given PDG Identifier pdgid.
 
         When a PdgData object is instantiated, the edition of the Review of Particle Physics
@@ -296,7 +301,7 @@ class PdgData(object):
         """
         return ''
 
-    def _get_pdgid(self):
+    def _get_pdgid(self) -> RowMapping:
         """Get PDG Identifier information."""
         if 'pdgid' not in self.cache:
             pdgid_table = self.api.db.tables['pdgid']
@@ -308,7 +313,7 @@ class PdgData(object):
                     raise PdgInvalidPdgIdError('PDG Identifier %s not found' % self.pdgid)
         return self.cache['pdgid']
 
-    def _get_summary_values(self):
+    def _get_summary_values(self) -> List[PdgSummaryValue]:
         """Get all summary data values."""
         if 'summary' not in self.cache:
             pdgid_table = self.api.db.tables['pdgid']
@@ -332,7 +337,7 @@ class PdgData(object):
         with self.api.engine.connect() as conn:
             return conn.execute(query, {'pdgid': pdgid.upper(), 'edition': edition}).scalar()
 
-    def get_parent_pdgid(self, include_edition=True):
+    def get_parent_pdgid(self, include_edition: bool=True) -> str:
         """Return PDG Identifier of this property's parent. In most cases, this
         will be the PDG ID of the particle itself. For those properties, such as
         neutrino mixing angles, that don't have a specific parent particle, the
@@ -397,22 +402,22 @@ class PdgData(object):
         self.cache = dict()
 
     @property
-    def description(self):
+    def description(self) -> str:
         """Description of data."""
         return self._get_pdgid()['description']
 
     @property
-    def data_type(self):
+    def data_type(self) -> str:
         """Type of data."""
         return self._get_pdgid()['data_type']
 
     @property
-    def data_flags(self):
+    def data_flags(self) -> str:
         """Flags augmenting data type information."""
         return self._get_pdgid()['flags']
 
     @property
-    def cp_charge_flag(self):
+    def cp_charge_flag(self) -> int:
         """The particular "CP charge" (see PdgParticle documentation) that
         this data corresponds to. This flag will be None if the data applies
         to all particles listed under the PDG identifier.
@@ -431,7 +436,7 @@ class PdgData(object):
 class PdgProperty(PdgData):
     """Base class for containers for data containers for particle properties."""
 
-    def summary_values(self, summary_table_only=False):
+    def summary_values(self, summary_table_only: bool=False) -> List[PdgSummaryValue]:
         """Return list of summary values for this quantity.
 
         By default, all summary values are included, even if they are only shown in the
@@ -447,7 +452,7 @@ class PdgProperty(PdgData):
         """Return number of summary values in Summary Table for this quantity."""
         return len(self.summary_values(summary_table_only=True))
 
-    def best_summary(self, summary_table_only=False):
+    def best_summary(self, summary_table_only: bool=False) -> PdgSummaryValue:
         """Return the PDG "best" summary value for this quantity.
 
         If there is either a single summary value in Particle Listings and Summary Tables, or there are multiple
@@ -498,7 +503,7 @@ class PdgProperty(PdgData):
                 yield PdgMeasurement(self.api, entry.id)
 
     @property
-    def num_measurements(self):
+    def num_measurements(self) -> int:
         """The number of measurements associated with this property."""
         pdgmsmt_table = self.api.db.tables['pdgmeasurement']
         query = select(func.count('*'))
@@ -512,27 +517,27 @@ class PdgProperty(PdgData):
         return self.best_summary().confidence_level
 
     @property
-    def is_limit(self):
+    def is_limit(self) -> bool:
         """Shortcut for best_summary().is_limit."""
         return self.best_summary().is_limit
 
     @property
-    def value(self):
+    def value(self) -> float:
         """Shortcut for best_summary().value."""
         return self.best_summary().value
 
     @property
-    def error(self):
+    def error(self) -> Optional[float]:
         """Shortcut for best_summary().error."""
         return self.best_summary().error
 
     @property
-    def error_positive(self):
+    def error_positive(self) -> float:
         """Shortcut for best_summary().error."""
         return self.best_summary().error_positive
 
     @property
-    def error_negative(self):
+    def error_negative(self) -> float:
         """Shortcut for best_summary().error."""
         return self.best_summary().error_negative
 
@@ -547,7 +552,7 @@ class PdgProperty(PdgData):
         return self.best_summary().units
 
     @property
-    def comment(self):
+    def comment(self) -> str:
         """Shortcut for best_summary().comment."""
         return self.best_summary().comment
 

--- a/pdg/data.py
+++ b/pdg/data.py
@@ -17,7 +17,7 @@ from pdg.units import UNIT_CONVERSION_FACTORS, convert
 from pdg.errors import PdgApiError, PdgInvalidPdgIdError, PdgAmbiguousValueError, PdgNoDataError
 from pdg.measurement import PdgMeasurement
 from sqlalchemy.engine.row import RowMapping
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, cast
 
 if TYPE_CHECKING:
     from pdg.api import PdgApi
@@ -283,7 +283,7 @@ class PdgData(object):
         if self._edition is None:
             self._edition = self.api.default_edition
         self.pdgid = make_id(self.baseid, self._edition)
-        self.cache = dict()
+        self.cache: dict[str, RowMapping | list[RowMapping] | list[PdgSummaryValue]] = {}
 
     def __str__(self):
         return 'Data for PDG Identifier %s: %s' % (self.pdgid, self.description)
@@ -313,6 +313,7 @@ class PdgData(object):
                     self.cache['pdgid'] = row._mapping
                 except AttributeError:
                     raise PdgInvalidPdgIdError('PDG Identifier %s not found' % self.pdgid)
+        assert isinstance(self.cache['pdgid'], RowMapping)
         return self.cache['pdgid']
 
     def _get_summary_values(self) -> List[PdgSummaryValue]:
@@ -324,11 +325,12 @@ class PdgData(object):
             query = query.where(pdgid_table.c.pdgid == bindparam('pdgid'))
             query = query.where(pdgdata_table.c.edition == bindparam('edition'))
             query = query.order_by(pdgdata_table.c.sort)
-            self.cache['summary'] = []
+            summary: list[PdgSummaryValue] = []
             with self.api.engine.connect() as conn:
                 for entry in conn.execute(query, {'pdgid': self.baseid, 'edition': self.edition}):
-                    self.cache['summary'].append(PdgSummaryValue(entry._mapping))
-        return self.cache['summary']
+                    summary.append(PdgSummaryValue(entry._mapping))
+            self.cache['summary'] = summary
+        return cast(list[PdgSummaryValue], self.cache['summary'])
 
     def _count_data_entries(self, pdgid, edition):
         """Count number of data entries for a given PDG identifier and edition."""

--- a/pdg/data.py
+++ b/pdg/data.py
@@ -36,7 +36,7 @@ class PdgSummaryValue(dict):
         """Print all data in this PdgSummaryValue object in a nice format (for debugging)."""
         pprint.pprint(self)
 
-    def get_value(self, units: Optional[str]=None) -> float:
+    def get_value(self, units: Optional[str]=None) -> Optional[float]:
         """Return value after conversion into units specified by parameter units (string).
 
         If units are not specified, the value is returned without conversion in the default units for this quantity.
@@ -72,7 +72,7 @@ class PdgSummaryValue(dict):
         else:
             return convert(self['error_negative'], self['unit_text'], units)
 
-    def get_error(self, units: Optional[str]=None) -> float:
+    def get_error(self, units: Optional[str]=None) -> Optional[float]:
         """Symmetric error or None, in units specified by parameter units (string).
 
         Returns symmetric error as average of positive and negative errors if they differ by less than 10% of
@@ -281,7 +281,7 @@ class PdgData(object):
         if self._edition is None:
             self._edition = edition
         if self._edition is None:
-            self._edition = self.api.edition
+            self._edition = self.api.default_edition
         self.pdgid = make_id(self.baseid, self._edition)
         self.cache = dict()
 
@@ -308,7 +308,9 @@ class PdgData(object):
             query = select(pdgid_table).where(pdgid_table.c.pdgid == bindparam('pdgid'))
             with self.api.engine.connect() as conn:
                 try:
-                    self.cache['pdgid'] = conn.execute(query, {'pdgid': self.baseid}).fetchone()._mapping
+                    row = conn.execute(query, {'pdgid': self.baseid}).fetchone()
+                    assert row is not None
+                    self.cache['pdgid'] = row._mapping
                 except AttributeError:
                     raise PdgInvalidPdgIdError('PDG Identifier %s not found' % self.pdgid)
         return self.cache['pdgid']
@@ -345,8 +347,6 @@ class PdgData(object):
         property's direct parent is a subsection header, it will be skipped, and
         the PDGID of the top-level section or particle will be returned
         instead."""
-        if self._get_pdgid()['parent_pdgid'] is None:
-            return None
         p = self
         while p._get_pdgid()['parent_pdgid'] is not None:
             p = self.api.get(p._get_pdgid()['parent_pdgid'], self.edition)
@@ -417,7 +417,7 @@ class PdgData(object):
         return self._get_pdgid()['flags']
 
     @property
-    def cp_charge_flag(self) -> int:
+    def cp_charge_flag(self) -> Optional[int]:
         """The particular "CP charge" (see PdgParticle documentation) that
         this data corresponds to. This flag will be None if the data applies
         to all particles listed under the PDG identifier.
@@ -452,7 +452,8 @@ class PdgProperty(PdgData):
         """Return number of summary values in Summary Table for this quantity."""
         return len(self.summary_values(summary_table_only=True))
 
-    def best_summary(self, summary_table_only: bool=False) -> PdgSummaryValue:
+    def best_summary(self, summary_table_only: bool=False) \
+            -> Optional[PdgSummaryValue]:
         """Return the PDG "best" summary value for this quantity.
 
         If there is either a single summary value in Particle Listings and Summary Tables, or there are multiple
@@ -509,62 +510,86 @@ class PdgProperty(PdgData):
         query = select(func.count('*'))
         query = query.where(pdgmsmt_table.c.pdgid == bindparam('pdgid'))
         with self.api.engine.connect() as conn:
-            return conn.execute(query, {'pdgid': self.baseid}).fetchone()[0]
+            row = conn.execute(query, {'pdgid': self.baseid}).fetchone()
+            assert row is not None
+            return row[0]
 
     @property
     def confidence_level(self):
         """Shortcut for best_summary().confidence_level."""
-        return self.best_summary().confidence_level
+        best = self.best_summary()
+        assert best is not None
+        return best.confidence_level
 
     @property
     def is_limit(self) -> bool:
         """Shortcut for best_summary().is_limit."""
-        return self.best_summary().is_limit
+        best = self.best_summary()
+        assert best is not None
+        return best.is_limit
 
     @property
     def value(self) -> float:
         """Shortcut for best_summary().value."""
-        return self.best_summary().value
+        best = self.best_summary()
+        assert best is not None
+        return best.value
 
     @property
     def error(self) -> Optional[float]:
         """Shortcut for best_summary().error."""
-        return self.best_summary().error
+        best = self.best_summary()
+        assert best is not None
+        return best.error
 
     @property
     def error_positive(self) -> float:
         """Shortcut for best_summary().error."""
-        return self.best_summary().error_positive
+        best = self.best_summary()
+        assert best is not None
+        return best.error_positive
 
     @property
     def error_negative(self) -> float:
         """Shortcut for best_summary().error."""
-        return self.best_summary().error_negative
+        best = self.best_summary()
+        assert best is not None
+        return best.error_negative
 
     @property
     def scale_factor(self):
         """Shortcut for best_summary().scale_factor."""
-        return self.best_summary().scale_factor
+        best = self.best_summary()
+        assert best is not None
+        return best.scale_factor
 
     @property
     def units(self):
         """Shortcut for best_summary().units."""
-        return self.best_summary().units
+        best = self.best_summary()
+        assert best is not None
+        return best.units
 
     @property
     def comment(self) -> str:
         """Shortcut for best_summary().comment."""
-        return self.best_summary().comment
+        best = self.best_summary()
+        assert best is not None
+        return best.comment
 
     @property
     def value_text(self):
         """Shortcut for best_summary().value_text."""
-        return self.best_summary().value_text
+        best = self.best_summary()
+        assert best is not None
+        return best.value_text
 
     @property
     def display_value_text(self):
         """Shortcut for best_summary().display_value_text."""
-        return self.best_summary().display_value_text
+        best = self.best_summary()
+        assert best is not None
+        return best.display_value_text
 
 
 class PdgMass(PdgProperty):

--- a/pdg/data.py
+++ b/pdg/data.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, List, Optional, cast
 
 if TYPE_CHECKING:
     from pdg.api import PdgApi
+    from pdg.particle import PdgParticle, PdgParticleList
 
 
 class PdgSummaryValue(dict):
@@ -295,7 +296,7 @@ class PdgData(object):
         return "%s('%s'%s)" % (self.__class__.__name__, make_id(self.baseid, self.edition),
                                extra)
 
-    def _repr_extra(self):
+    def _repr_extra(self) -> str:
         """A method that subclasses can override in order to add info to the
         result of __repr__.
         """
@@ -354,15 +355,15 @@ class PdgData(object):
             p = self.api.get(p._get_pdgid()['parent_pdgid'], self.edition)
         return p.pdgid if include_edition else p.baseid
 
-    def get_particles(self):
+    def get_particles(self) -> 'PdgParticleList':
         """Return PdgParticleList for this property's particle."""
         p = self.api.get(self.get_parent_pdgid())
         if p.data_type != 'PART':
             err = 'Identifier %s does not have a parent particle'
             raise PdgNoDataError(err)
-        return p
+        return cast('PdgParticleList', p)
 
-    def get_particle(self):
+    def get_particle(self) -> 'PdgParticle':
         """Returns PdgParticle for this property's particle. Raises
         PdgAmbiguousValueError when there are multiple matches."""
         ps = self.get_particles()

--- a/pdg/decay.py
+++ b/pdg/decay.py
@@ -8,7 +8,7 @@ from pdg.data import PdgProperty
 from pdg.errors import PdgAmbiguousValueError, PdgInvalidPdgIdError, PdgNoDataError
 from pdg.particle import PdgItem, PdgParticle
 from sqlalchemy.engine.row import RowMapping
-from typing import List
+from typing import List, Optional
 
 
 class PdgDecayProduct(object):
@@ -16,7 +16,8 @@ class PdgDecayProduct(object):
     PdgItem (which may resolve to one or more PdgParticles), its multiplier, and
     its subdecay (if any).
     """
-    def __init__(self, item: PdgItem, multiplier: int, subdecay: None):
+    def __init__(self, item: PdgItem, multiplier: int,
+                 subdecay: Optional[PdgBranchingFraction]=None):
         """Instantiate a PdgDecayProduct."""
         assert isinstance(item, PdgItem)
         assert isinstance(multiplier, int)

--- a/pdg/decay.py
+++ b/pdg/decay.py
@@ -8,7 +8,7 @@ from pdg.data import PdgProperty
 from pdg.errors import PdgAmbiguousValueError, PdgInvalidPdgIdError, PdgNoDataError
 from pdg.particle import PdgItem, PdgParticle
 from sqlalchemy.engine.row import RowMapping
-from typing import List, Optional
+from typing import List, Optional, cast
 
 
 class PdgDecayProduct(object):
@@ -46,8 +46,8 @@ class PdgBranchingFraction(PdgProperty):
                     result = conn.execute(query, {'pdgid': self.baseid}).fetchall()
                     self.cache['pdgdecay'] = [row._mapping for row in result]
                 except AttributeError:
-                    raise PdgInvalidPdgIdError('No PDGDECAY entry for ' % self.pdgid)
-        return self.cache['pdgdecay']
+                    raise PdgInvalidPdgIdError('No PDGDECAY entry for %s' % self.pdgid)
+        return cast(list[RowMapping], self.cache['pdgdecay'])
 
     def _repr_extra(self):
         return '"%s"' % self.description

--- a/pdg/decay.py
+++ b/pdg/decay.py
@@ -8,7 +8,7 @@ from pdg.data import PdgProperty
 from pdg.errors import PdgAmbiguousValueError, PdgInvalidPdgIdError, PdgNoDataError
 from pdg.particle import PdgItem, PdgParticle
 from sqlalchemy.engine.row import RowMapping
-from typing import List, Optional, cast
+from typing import Iterator, Optional, cast
 
 
 class PdgDecayProduct(object):
@@ -19,15 +19,11 @@ class PdgDecayProduct(object):
     def __init__(self, item: PdgItem, multiplier: int,
                  subdecay: Optional['PdgBranchingFraction']=None):
         """Instantiate a PdgDecayProduct."""
-        assert isinstance(item, PdgItem)
-        assert isinstance(multiplier, int)
-        assert subdecay is None or isinstance(subdecay, PdgBranchingFraction)
-
         self.item = item
         self.multiplier = multiplier
         self.subdecay = subdecay
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         fmt = "PdgDecayProduct(item='%s', multiplier=%d, subdecay=%r)"
         return fmt % (self.item.name, self.multiplier, self.subdecay)
 
@@ -36,7 +32,7 @@ class PdgBranchingFraction(PdgProperty):
     """Class for all information about a decay, including its branching
     fraction, decay products, and subdecays.
     """
-    def _get_decay(self) -> List[RowMapping]:
+    def _get_decay(self) -> list[RowMapping]:
         """Load decay information from the database."""
         if 'pdgdecay' not in self.cache:
             pdgdecay_table = self.api.db.tables['pdgdecay']
@@ -49,11 +45,11 @@ class PdgBranchingFraction(PdgProperty):
                     raise PdgInvalidPdgIdError('No PDGDECAY entry for %s' % self.pdgid)
         return cast(list[RowMapping], self.cache['pdgdecay'])
 
-    def _repr_extra(self):
+    def _repr_extra(self) -> str:
         return '"%s"' % self.description
 
     @property
-    def decay_products(self) -> List[PdgDecayProduct]:
+    def decay_products(self) -> list[PdgDecayProduct]:
         """A list of all PdgDecayProducts for the decay."""
         products = []
         for row in self._get_decay():
@@ -69,7 +65,7 @@ class PdgBranchingFraction(PdgProperty):
         return products
 
     @property
-    def mode_number(self):
+    def mode_number(self) -> int:
         """Mode number of this decay.
 
         Note that the decay mode number may change from one edition of the Review of Particle Physics
@@ -93,7 +89,7 @@ class PdgBranchingFraction(PdgProperty):
         else:
             return 0
 
-    def subdecays(self):
+    def subdecays(self) -> Iterator['PdgBranchingFraction']:
         """Return iterator over all subdecays of this decay. Warning: Subdecay
         data is returned as-is from the Particle Listings. Its interpretation
         will depend on the conventions used by the specific section of the
@@ -115,7 +111,7 @@ class PdgBranchingFraction(PdgProperty):
         for row in matches:
             yield PdgBranchingFraction(self.api, row.pdgid, self.edition)
 
-    def branching_ratios(self):
+    def branching_ratios(self) -> Iterator['PdgBranchingRatio']:
         """Return iterator over all branching ratios associated with this
         branching fraction."""
         pdgid_map = self.api.db.tables['pdgid_map']
@@ -129,7 +125,7 @@ class PdgBranchingFraction(PdgProperty):
 
 class PdgBranchingRatio(PdgProperty):
     """Class for all information about a branching ratio."""
-    def branching_fractions(self):
+    def branching_fractions(self) -> Iterator[PdgBranchingFraction]:
         """Return iterator over all branching fractions associated with this
         branching ratio."""
         pdgid_map = self.api.db.tables['pdgid_map']
@@ -140,5 +136,5 @@ class PdgBranchingRatio(PdgProperty):
         for row in matches:
             yield PdgBranchingFraction(self.api, row.source, self.edition)
 
-    def _repr_extra(self):
+    def _repr_extra(self) -> str:
         return '"%s"' % self.description

--- a/pdg/decay.py
+++ b/pdg/decay.py
@@ -17,7 +17,7 @@ class PdgDecayProduct(object):
     its subdecay (if any).
     """
     def __init__(self, item: PdgItem, multiplier: int,
-                 subdecay: Optional[PdgBranchingFraction]=None):
+                 subdecay: Optional['PdgBranchingFraction']=None):
         """Instantiate a PdgDecayProduct."""
         assert isinstance(item, PdgItem)
         assert isinstance(multiplier, int)

--- a/pdg/decay.py
+++ b/pdg/decay.py
@@ -7,6 +7,8 @@ from sqlalchemy import bindparam, select
 from pdg.data import PdgProperty
 from pdg.errors import PdgAmbiguousValueError, PdgInvalidPdgIdError, PdgNoDataError
 from pdg.particle import PdgItem, PdgParticle
+from sqlalchemy.engine.row import RowMapping
+from typing import List
 
 
 class PdgDecayProduct(object):
@@ -14,7 +16,7 @@ class PdgDecayProduct(object):
     PdgItem (which may resolve to one or more PdgParticles), its multiplier, and
     its subdecay (if any).
     """
-    def __init__(self, item, multiplier, subdecay):
+    def __init__(self, item: PdgItem, multiplier: int, subdecay: None):
         """Instantiate a PdgDecayProduct."""
         assert isinstance(item, PdgItem)
         assert isinstance(multiplier, int)
@@ -33,7 +35,7 @@ class PdgBranchingFraction(PdgProperty):
     """Class for all information about a decay, including its branching
     fraction, decay products, and subdecays.
     """
-    def _get_decay(self):
+    def _get_decay(self) -> List[RowMapping]:
         """Load decay information from the database."""
         if 'pdgdecay' not in self.cache:
             pdgdecay_table = self.api.db.tables['pdgdecay']
@@ -50,7 +52,7 @@ class PdgBranchingFraction(PdgProperty):
         return '"%s"' % self.description
 
     @property
-    def decay_products(self):
+    def decay_products(self) -> List[PdgDecayProduct]:
         """A list of all PdgDecayProducts for the decay."""
         products = []
         for row in self._get_decay():
@@ -74,7 +76,7 @@ class PdgBranchingFraction(PdgProperty):
         return self._get_pdgid()['mode_number']
 
     @property
-    def is_subdecay(self):
+    def is_subdecay(self) -> bool:
         """True if this is a subdecay ("indented") decay mode."""
         data_type_code = self.data_type
         if len(data_type_code) < 4:
@@ -83,7 +85,7 @@ class PdgBranchingFraction(PdgProperty):
             return data_type_code[0:3] == 'BFX' or data_type_code[0:3] == 'BFI'
 
     @property
-    def subdecay_level(self):
+    def subdecay_level(self) -> int:
         """Return indentation level of a decay mode."""
         if self.is_subdecay:
             return int(self.data_type[3])

--- a/pdg/measurement.py
+++ b/pdg/measurement.py
@@ -3,7 +3,8 @@
 from pdg.errors import PdgAmbiguousValueError
 from pdg.utils import get_linked_ids, get_row_data
 from sqlalchemy.engine.row import RowMapping
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Iterator, Optional
+from typing_extensions import deprecated
 
 if TYPE_CHECKING:
     from pdg.api import PdgApi
@@ -21,7 +22,7 @@ class PdgMeasurement(object):
             'pdgmeasurement',
             get_row_data(self.api, 'pdgmeasurement', self.id))
 
-    def values(self):
+    def values(self) -> Iterator['PdgValue']:
         """Returns a iterator of PdgValues for all of the quanities associated
            with this measurement."""
         for value_id in get_linked_ids(
@@ -31,7 +32,7 @@ class PdgMeasurement(object):
                 self.id):
             yield PdgValue(self.api, value_id)
 
-    def get_value(self):
+    def get_value(self) -> 'PdgValue':
         """Returns the PdgValue associated with this measurement. Raises
         PdgAmbiguousValueError if there are multiple values (i.e. this is a
         multi-column measurement)."""
@@ -42,7 +43,7 @@ class PdgMeasurement(object):
             raise PdgAmbiguousValueError(err)
         return vs[0]
 
-    def footnotes(self):
+    def footnotes(self) -> Iterator['PdgFootnote']:
         """Returns an iterator of PdgFootnotes for this measurements."""
         for foot_id in get_linked_ids(
                 self.api,
@@ -69,7 +70,7 @@ class PdgMeasurement(object):
         return self._get_measurement_data()['event_count']
 
     @property
-    def confidence_level(self) -> None:
+    def confidence_level(self) -> Optional[float]:
         """The confidence level of this measurement."""
         return self._get_measurement_data()['confidence_level']
 
@@ -122,7 +123,7 @@ class PdgValue(object):
         return self._get_value_data()['column_name']
 
     @property
-    def column_name_tex(self):
+    def column_name_tex(self) -> str:
         """The name of the column (in TeX format) in which this value is
         displayed in the PDG Listings."""
         return self._get_value_data()['column_name_tex']
@@ -203,12 +204,12 @@ class PdgValue(object):
         return self._get_value_data()['value']
 
     @property
-    def error_positive(self) -> float:
+    def error_positive(self) -> Optional[float]:
         """The total positive error for this value."""
         return self._get_value_data()['error_positive']
 
     @property
-    def error_negative(self) -> float:
+    def error_negative(self) -> Optional[float]:
         """The total negative error for this value."""
         return self._get_value_data()['error_negative']
 
@@ -233,7 +234,7 @@ class PdgValue(object):
         return self._get_value_data()['syst_error_negative']
 
     @property
-    def error(self):
+    def error(self) -> Optional[float]:
         """The total symmetric error for this value. If the positive and
            negative errors differ, accessing this property will give the average
            of the two, unless you are in pedantic mode, in which case a
@@ -248,7 +249,7 @@ class PdgValue(object):
         return 0.5*(self.error_positive + self.error_negative)
 
     @property
-    def stat_error(self):
+    def stat_error(self) -> Optional[float]:
         """The statistical symmetric error for this value. If the positive and
            negative statistical errors differ, accessing this property will give
            the average of the two, unless you are in pedantic mode, in which case a
@@ -263,7 +264,7 @@ class PdgValue(object):
         return 0.5*(self.stat_error_positive + self.stat_error_negative)
 
     @property
-    def syst_error(self):
+    def syst_error(self) -> Optional[float]:
         """The systematic symmetric error for this value. If the positive and
            negative systematic errors differ, accessing this property will give
            the average of the two, unless you are in pedantic mode, in which case a
@@ -318,7 +319,7 @@ class PdgReference(object):
         return self._get_reference_data()['inspire_id']
 
     @property
-    def document_id(self):
+    def document_id(self) -> str:
         """The identifier for this publication in AUTHOR YEAR format."""
         return self._get_reference_data()['document_id']
 
@@ -336,8 +337,12 @@ class PdgFootnote(object):
             'pdgfootnote',
             get_row_data(self.api, 'pdgfootnote', self.id))
 
-    def references(self):
-        """Returns an iterator of PdgReferences that refer to this footnote."""
+    @deprecated('Use "measurements" instead')
+    def references(self) -> Iterator[PdgMeasurement]:
+        return self.measurements()
+
+    def measurements(self) -> Iterator[PdgMeasurement]:
+        """Returns an iterator of PdgMeasurements that refer to this footnote."""
         for ref_id in get_linked_ids(
                 self.api,
                 'pdgmeasurement_footnote',

--- a/pdg/measurement.py
+++ b/pdg/measurement.py
@@ -2,16 +2,21 @@
 
 from pdg.errors import PdgAmbiguousValueError
 from pdg.utils import get_linked_ids, get_row_data
+from sqlalchemy.engine.row import RowMapping
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from pdg.api import PdgApi
 
 class PdgMeasurement(object):
     """Class for an individual measurement from the PDG Listings."""
 
-    def __init__(self, api, msmt_id):
+    def __init__(self, api: 'PdgApi', msmt_id: int):
         self.api = api
         self.id = msmt_id
         self.cache = {}
 
-    def _get_measurement_data(self):
+    def _get_measurement_data(self) -> RowMapping:
         return self.cache.get(
             'pdgmeasurement',
             get_row_data(self.api, 'pdgmeasurement', self.id))
@@ -48,45 +53,45 @@ class PdgMeasurement(object):
             yield PdgFootnote(self.api, foot_id)
 
     @property
-    def reference(self):
+    def reference(self) -> 'PdgReference':
         """The PdgReference associated with this measurement."""
         ref_id = self._get_measurement_data()['pdgreference_id']
         return PdgReference(self.api, ref_id)
 
     @property
-    def pdgid(self):
+    def pdgid(self) -> str:
         """The PDG Identifier to which this measurement applies."""
         return self._get_measurement_data()['pdgid']
 
     @property
-    def event_count(self):
+    def event_count(self) -> str:
         """The number of events in the sample used for this measurement."""
         return self._get_measurement_data()['event_count']
 
     @property
-    def confidence_level(self):
+    def confidence_level(self) -> None:
         """The confidence level of this measurement."""
         return self._get_measurement_data()['confidence_level']
 
     @property
-    def technique(self):
+    def technique(self) -> str:
         """The technique used in this measurement."""
         return self._get_measurement_data()['technique']
 
     @property
-    def charge(self):
+    def charge(self) -> str:
         """Case-specific representation of the charge(s) of the particles
            involved in this measurement."""
         return self._get_measurement_data()['charge']
 
     @property
-    def changebar(self):
+    def changebar(self) -> bool:
         """True if this measurement has been added or updated since the previous
            PDG edition"""
         return self._get_measurement_data()['changebar']
 
     @property
-    def comment(self):
+    def comment(self) -> str:
         """Inline comment displayed with this measurement in the PDG Listings."""
         return self._get_measurement_data()['comment']
 
@@ -94,24 +99,24 @@ class PdgMeasurement(object):
 class PdgValue(object):
     """Class for an individual numerical value associated with a PdgMeasurement."""
 
-    def __init__(self, api, value_id):
+    def __init__(self, api: 'PdgApi', value_id: int):
         self.api = api
         self.id = value_id
         self.cache = {}
 
-    def _get_value_data(self):
+    def _get_value_data(self) -> RowMapping:
         return self.cache.get(
             'pdgmeasurement_values',
             get_row_data(self.api, 'pdgmeasurement_values', self.id))
 
     @property
-    def measurement(self):
+    def measurement(self) -> PdgMeasurement:
         """The corresponding PdgMeasurement for this value."""
         msmt_id = self._get_value_data()['pdgmeasurement_id']
         return PdgMeasurement(self.api, msmt_id)
 
     @property
-    def column_name(self):
+    def column_name(self) -> str:
         """The name of the column (in plain text format) in which this value is
            displayed in the PDG Listings."""
         return self._get_value_data()['column_name']
@@ -123,7 +128,7 @@ class PdgValue(object):
         return self._get_value_data()['column_name_tex']
 
     @property
-    def unit_text(self):
+    def unit_text(self) -> str:
         """The units (in plain text format) in which this value is specified."""
         return self._get_value_data()['unit_text']
 
@@ -133,7 +138,7 @@ class PdgValue(object):
     #     return self._get_value_data()['unit_tex']
 
     @property
-    def value_text(self):
+    def value_text(self) -> str:
         """Value and uncertainty (in plain text format) in units given by
            property units, including the power of ten, if applicable
            (see display_power_of_ten)"""
@@ -147,7 +152,7 @@ class PdgValue(object):
     #     return self._get_value_data()['value_tex']
 
     @property
-    def display_value_text(self):
+    def display_value_text(self) -> str:
         """Value and uncertainty in plain text format as displayed in
            Listings tables. Does not include any power of ten or percent sign.
            Must be combined with the display_power_of_ten property in order
@@ -155,75 +160,75 @@ class PdgValue(object):
         return self._get_value_data()['display_value_text']
 
     @property
-    def display_power_of_ten(self):
+    def display_power_of_ten(self) -> int:
         """Unit multiplier (as power of ten) as used for display in Listings."""
         return self._get_value_data()['display_power_of_ten']
 
     @property
-    def display_in_percent(self):
+    def display_in_percent(self) -> bool:
         """True if value is rendered in percent for display in Listings.
            Implies that display_power_of_ten is -2."""
         return self._get_value_data()['display_in_percent']
 
     @property
-    def is_limit(self):
+    def is_limit(self) -> bool:
         """True if value is a limit."""
         return self._get_value_data()['limit_type'] is not None
 
     @property
-    def is_upper_limit(self):
+    def is_upper_limit(self) -> bool:
         """True if value is an upper limit."""
         return self._get_value_data()['limit_type'] == 'U'
 
     @property
-    def is_lower_limit(self):
+    def is_lower_limit(self) -> bool:
         """True if value is a lower limit."""
         return self._get_value_data()['limit_type'] == 'L'
 
     @property
-    def used_in_average(self):
+    def used_in_average(self) -> bool:
         """True if value is used for calculating averages shown in
            Summary Tables."""
         return self._get_value_data()['used_in_average']
 
     @property
-    def used_in_fit(self):
+    def used_in_fit(self) -> bool:
         """True if value is used for calculating best-fits shown in
            Summary Tables."""
         return self._get_value_data()['used_in_fit']
 
     @property
-    def value(self):
+    def value(self) -> float:
         """The numerical value itself."""
         return self._get_value_data()['value']
 
     @property
-    def error_positive(self):
+    def error_positive(self) -> float:
         """The total positive error for this value."""
         return self._get_value_data()['error_positive']
 
     @property
-    def error_negative(self):
+    def error_negative(self) -> float:
         """The total negative error for this value."""
         return self._get_value_data()['error_negative']
 
     @property
-    def stat_error_positive(self):
+    def stat_error_positive(self) -> Optional[float]:
         """The statistical component of the positive error for this value."""
         return self._get_value_data()['stat_error_positive']
 
     @property
-    def stat_error_negative(self):
+    def stat_error_negative(self) -> Optional[float]:
         """The statistical component of the negative error for this value."""
         return self._get_value_data()['stat_error_negative']
 
     @property
-    def syst_error_positive(self):
+    def syst_error_positive(self) -> Optional[float]:
         """The systematic component of the positive error for this value."""
         return self._get_value_data()['syst_error_positive']
 
     @property
-    def syst_error_negative(self):
+    def syst_error_negative(self) -> Optional[float]:
         """The systematic component of the negative error for this value."""
         return self._get_value_data()['syst_error_negative']
 
@@ -276,39 +281,39 @@ class PdgValue(object):
 class PdgReference(object):
     """Class for literature references associated with PdgMeasurements."""
 
-    def __init__(self, api, ref_id):
+    def __init__(self, api: 'PdgApi', ref_id: int):
         self.api = api
         self.id = ref_id
         self.cache = {}
 
-    def _get_reference_data(self):
+    def _get_reference_data(self) -> RowMapping:
         return self.cache.get(
             'pdgreference',
             get_row_data(self.api, 'pdgreference', self.id))
 
     @property
-    def publication_name(self):
+    def publication_name(self) -> str:
         """The abbreviated bibliographic name (e.g. journal initials, issue,
            page) of this publication."""
         return self._get_reference_data()['publication_name']
 
     @property
-    def publication_year(self):
+    def publication_year(self) -> int:
         """The year of this publication."""
         return self._get_reference_data()['publication_year']
 
     @property
-    def title(self):
+    def title(self) -> str:
         """The title of this publication."""
         return self._get_reference_data()['title']
 
     @property
-    def doi(self):
+    def doi(self) -> str:
         """The DOI of this publication."""
         return self._get_reference_data()['doi']
 
     @property
-    def inspire_id(self):
+    def inspire_id(self) -> str:
         """The INSPIRE identifier of this publication."""
         return self._get_reference_data()['inspire_id']
 
@@ -321,12 +326,12 @@ class PdgReference(object):
 class PdgFootnote(object):
     """Class for footnotes associated with PdgReferences."""
 
-    def __init__(self, api, foot_id):
+    def __init__(self, api: 'PdgApi', foot_id: int):
         self.api = api
         self.id = foot_id
         self.cache = {}
 
-    def _get_footnote_data(self):
+    def _get_footnote_data(self) -> RowMapping:
         return self.cache.get(
             'pdgfootnote',
             get_row_data(self.api, 'pdgfootnote', self.id))
@@ -342,7 +347,7 @@ class PdgFootnote(object):
             yield PdgMeasurement(self.api, ref_id)
 
     @property
-    def text(self):
+    def text(self) -> str:
         """The footnote text, in plain text format."""
         return self._get_footnote_data()['text']
 

--- a/pdg/measurement.py
+++ b/pdg/measurement.py
@@ -14,7 +14,7 @@ class PdgMeasurement(object):
     def __init__(self, api: 'PdgApi', msmt_id: int):
         self.api = api
         self.id = msmt_id
-        self.cache = {}
+        self.cache: dict[str, RowMapping] = {}
 
     def _get_measurement_data(self) -> RowMapping:
         return self.cache.get(
@@ -102,7 +102,7 @@ class PdgValue(object):
     def __init__(self, api: 'PdgApi', value_id: int):
         self.api = api
         self.id = value_id
-        self.cache = {}
+        self.cache: dict[str, RowMapping] = {}
 
     def _get_value_data(self) -> RowMapping:
         return self.cache.get(
@@ -284,7 +284,7 @@ class PdgReference(object):
     def __init__(self, api: 'PdgApi', ref_id: int):
         self.api = api
         self.id = ref_id
-        self.cache = {}
+        self.cache: dict[str, RowMapping] = {}
 
     def _get_reference_data(self) -> RowMapping:
         return self.cache.get(
@@ -329,7 +329,7 @@ class PdgFootnote(object):
     def __init__(self, api: 'PdgApi', foot_id: int):
         self.api = api
         self.id = foot_id
-        self.cache = {}
+        self.cache: dict[str, RowMapping] = {}
 
     def _get_footnote_data(self) -> RowMapping:
         return self.cache.get(

--- a/pdg/particle.py
+++ b/pdg/particle.py
@@ -6,9 +6,13 @@ from sqlalchemy import select, bindparam, distinct, func
 from sqlalchemy import and_, or_
 from pdg.errors import PdgApiError, PdgNoDataError, PdgAmbiguousValueError
 from pdg.utils import make_id
-from pdg.data import PdgData
+from pdg.data import PdgLifetime, PdgMass, PdgWidth, PdgData
 from pdg.units import HBAR_IN_GEV_S
+from sqlalchemy.engine.row import RowMapping
+from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Union
 
+if TYPE_CHECKING:
+    from pdg.api import PdgApi
 
 class PdgItem:
     """A class to represent an "item" encountered in e.g. a description of a
@@ -18,7 +22,7 @@ class PdgItem:
     queried (via the particle/particles properties) for the associated
     particle(s).
     """
-    def __init__(self, api, pdgitem_id, edition=None):
+    def __init__(self, api: 'PdgApi', pdgitem_id: int, edition: None=None):
         """Constructor for a PdgItem. Intended for internal API use."""
         self.api = api
         self.pdgitem_id = pdgitem_id
@@ -30,7 +34,7 @@ class PdgItem:
         name = self._get_pdgitem()['name']
         return 'PdgItem("%s")' % name
 
-    def _get_pdgitem(self):
+    def _get_pdgitem(self) -> RowMapping:
         """Load the PdgItem's data from the database."""
         if 'pdgitem' not in self.cache:
             pdgitem_table = self.api.db.tables['pdgitem']
@@ -52,7 +56,7 @@ class PdgItem:
                 yield PdgItem(self.api, row.target_id)
 
     @property
-    def has_particle(self):
+    def has_particle(self) -> bool:
         """Whether the PdgItem is associated with exactly one particle. The
         property has_particles indicates whether it is associated with one or
         more.
@@ -75,7 +79,7 @@ class PdgItem:
         return self.cache['has_particle']
 
     @property
-    def particle(self):
+    def particle(self) -> 'PdgParticle':
         """The particle associated with the PdgItem, if there is exactly one
         such particle. Raises PdgAmbiguousValueError if there are more than one,
         in which case the particles property can be used instead.
@@ -89,7 +93,7 @@ class PdgItem:
                            set_name=p['name'])
 
     @property
-    def particles(self):
+    def particles(self) -> List['PdgParticle']:
         """The list of all particles associated with the PdgItem."""
         if self.has_particle:
             return [self.particle]
@@ -101,12 +105,12 @@ class PdgItem:
             return result
 
     @property
-    def has_particles(self):
+    def has_particles(self) -> bool:
         """Whether the PdgItem is associated with at least one particle."""
         return len(list(self.particles)) > 0
 
     @property
-    def name(self):
+    def name(self) -> str:
         """The name of the PdgItem."""
         return self._get_pdgitem()['name']
 
@@ -116,7 +120,7 @@ class PdgItem:
     #     return self._get_pdgitem()['name_tex']
 
     @property
-    def item_type(self):
+    def item_type(self) -> str:
         """The type of the PdgItem. A single character with the following meanings:
               'P': specific state (e.g. "pi+"),
               'A': "also" alias,
@@ -140,7 +144,7 @@ class PdgParticle(PdgData):
     in Particle Listings and Summary Tables, including branching fractions, masses, life-times, etc.
     """
 
-    def __init__(self, api, pdgid, edition=None, set_mcid=None, set_name=None):
+    def __init__(self, api: 'PdgApi', pdgid: str, edition: Optional[str]=None, set_mcid: Optional[int]=None, set_name: Optional[str]=None):
         """Constructor for a PdgParticle given its PDG Identifier and possibly its MC ID."""
         super(PdgParticle, self).__init__(api, pdgid, edition)
         self.set_mcid = set_mcid
@@ -155,7 +159,7 @@ class PdgParticle(PdgData):
     def _repr_extra(self):
         return "name='%s'" % self.name
 
-    def best(self, properties, quantity=None):
+    def best(self, properties: Iterator[Any], quantity: Optional[str]=None) -> Union[PdgMass, PdgLifetime, PdgWidth]:
         """Return the "best" property from an iterable of properties, using the API's pedantic setting.
 
         quantity is an optional string that describes what was being sought in case of error.
@@ -202,7 +206,7 @@ class PdgParticle(PdgData):
             else:
                 return props[0]
 
-    def _get_particle_data(self):
+    def _get_particle_data(self) -> RowMapping:
         """Get particle data."""
         if 'pdgparticle' not in self.cache:
             pdgparticle_table = self.api.db.tables['pdgparticle']
@@ -240,10 +244,10 @@ class PdgParticle(PdgData):
         return self.cache['pdgparticle']
 
     def properties(self,
-                   data_type_key=None,
-                   require_summary_data=True,
-                   in_summary_table=None,
-                   omit_branching_ratios=False):
+                   data_type_key: Optional[str]=None,
+                   require_summary_data: bool=True,
+                   in_summary_table: None=None,
+                   omit_branching_ratios: bool=False):
         """Return iterator over specified particle property data.
 
         By default, all properties excluding branching fractions and branching fraction ratios are returned.
@@ -317,7 +321,7 @@ class PdgParticle(PdgData):
                     yield prop
 
 
-    def masses(self, require_summary_data=True):
+    def masses(self, require_summary_data: bool=True) -> Iterator[Any]:
         """Return iterator over mass data.
 
         For most particles, there is only a single mass property, and so the particle's
@@ -330,11 +334,11 @@ class PdgParticle(PdgData):
         """
         return self.properties('M', require_summary_data)
 
-    def widths(self, require_summary_data=True):
+    def widths(self, require_summary_data: bool=True) -> Iterator[Any]:
         """Return iterator over width data."""
         return self.properties('G', require_summary_data)
 
-    def lifetimes(self, require_summary_data=True):
+    def lifetimes(self, require_summary_data: bool=True) -> Iterator[Any]:
         """Return iterator over lifetime data."""
         return self.properties('T', require_summary_data)
 
@@ -379,17 +383,17 @@ class PdgParticle(PdgData):
             return self.branching_fractions('BFI', require_summary_data)
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Name of particle (ASCII format)."""
         return self._get_particle_data()['name']
 
     @property
-    def mcid(self):
+    def mcid(self) -> int:
         """Monte Carlo ID of particle."""
         return self._get_particle_data()['mcid']
 
     @property
-    def charge(self):
+    def charge(self) -> float:
         """Charge of particle in units of e."""
         return self._get_particle_data()['charge']
 
@@ -409,7 +413,7 @@ class PdgParticle(PdgData):
         return self._get_particle_data()['quantum_j']
 
     @property
-    def quantum_P(self):
+    def quantum_P(self) -> str:
         """Quantum number P (parity) of particle."""
         return self._get_particle_data()['quantum_p']
 
@@ -419,32 +423,32 @@ class PdgParticle(PdgData):
         return self._get_particle_data()['quantum_c']
 
     @property
-    def is_boson(self):
+    def is_boson(self) -> bool:
         """True if particle is a gauge boson."""
         return 'G' in self.data_flags
 
     @property
-    def is_quark(self):
+    def is_quark(self) -> bool:
         """True if particle is a quark."""
         return 'Q' in self.data_flags
 
     @property
-    def is_lepton(self):
+    def is_lepton(self) -> bool:
         """True if particle is a lepton."""
         return 'L' in self.data_flags
 
     @property
-    def is_meson(self):
+    def is_meson(self) -> bool:
         """True if particle is a meson."""
         return 'M' in self.data_flags
 
     @property
-    def is_baryon(self):
+    def is_baryon(self) -> bool:
         """True if particle is a baryon."""
         return 'B' in self.data_flags
 
     @staticmethod
-    def _if_not_limit(prop, units, error=False):
+    def _if_not_limit(prop: Union[PdgMass, PdgLifetime, PdgWidth], units: str, error: bool=False) -> float:
         """If a PdgProperty's best summary value is NOT a limit, return it in
         the specified units. Otherwise return None. If error is True, return the
         error instead of the value.
@@ -457,7 +461,7 @@ class PdgParticle(PdgData):
         return summary.get_value(units)
 
     @property
-    def mass(self):
+    def mass(self) -> float:
         """Mass of the particle in GeV."""
         best_mass_property = self.best(self.masses(), '%s mass (%s)' % (self.name, self.pdgid))
         return self._if_not_limit(best_mass_property, 'GeV')
@@ -469,7 +473,7 @@ class PdgParticle(PdgData):
         return self._if_not_limit(best_mass_property, 'GeV', error=True)
 
     @property
-    def width(self):
+    def width(self) -> float:
         """Width of the particle in GeV."""
         try:
             best_width_property = self.best(self.widths(), '%s width (%s)' % (self.name, self.pdgid))
@@ -483,7 +487,7 @@ class PdgParticle(PdgData):
             return HBAR_IN_GEV_S / self.lifetime
 
     @property
-    def width_error(self):
+    def width_error(self) -> float:
         """Symmetric error on width of particle in GeV, or None if width error are asymmetric or width is a limit."""
         try:
             best_width_property = self.best(self.widths(), '%s (%s)' % (self.pdgid, self.description))
@@ -497,7 +501,7 @@ class PdgParticle(PdgData):
             return self.lifetime_error * HBAR_IN_GEV_S / self.lifetime**2
 
     @property
-    def lifetime(self):
+    def lifetime(self) -> float:
         """Lifetime of the particle in seconds."""
         try:
             best_lifetime_property = self.best(self.lifetimes(), '%s lifetime (%s)' % (self.name, self.pdgid))
@@ -510,7 +514,7 @@ class PdgParticle(PdgData):
             return HBAR_IN_GEV_S / self.width
 
     @property
-    def lifetime_error(self):
+    def lifetime_error(self) -> float:
         """Symmetric error on lifetime of particle in seconds, or None if lifetime error are asymmetric or lifetime is a limit."""
         try:
             best_lifetime_property = self.best(self.lifetimes(), '%s (%s)' % (self.pdgid, self.description))
@@ -531,17 +535,17 @@ class PdgParticle(PdgData):
         return next(self.masses(), None) is not None
 
     @property
-    def has_width_entry(self):
+    def has_width_entry(self) -> bool:
         """Whether the particle has at least one defined decay width."""
         return next(self.widths(), None) is not None
 
     @property
-    def has_lifetime_entry(self):
+    def has_lifetime_entry(self) -> bool:
         """Whether the particle has at least one defined lifetime."""
         return next(self.lifetimes(), None) is not None
 
     @property
-    def cp_charge(self):
+    def cp_charge(self) -> int:
         """The charge of the nominal "particle" (as opposed to "antiparticle")
         for this species. E.g., for the proton and antiproton, this is 1.
         Useful for distinguishing e.g. the Sigma_b()+ (and Sigmabar_b()-)
@@ -552,12 +556,12 @@ class PdgParticle(PdgData):
         sign = -1 if cc_type == 'A' else 1
         return sign * int(self.charge)
 
-    def mass_measurements(self, require_summary_data=True):
+    def mass_measurements(self, require_summary_data: bool=True):
         for m in self.masses(require_summary_data=require_summary_data):
             for msmt in m.get_measurements():
                 yield msmt
 
-    def lifetime_measurements(self, require_summary_data=True):
+    def lifetime_measurements(self, require_summary_data: bool=True):
         for t in self.lifetimes(require_summary_data=require_summary_data):
             for msmt in t.get_measurements():
                 yield msmt
@@ -573,7 +577,7 @@ class PdgParticleList(PdgData, list):
     is returned when PdgApi.get is called with the PDGID of a (group of)
     particles.
     """
-    def __init__(self, api, pdgid, edition=None):
+    def __init__(self, api: 'PdgApi', pdgid: str, edition: Optional[str]=None):
         """Constructor for a PdgParticleList given its PDG Identifier."""
         super(PdgParticleList, self).__init__(api, pdgid, edition)
 

--- a/pdg/particle.py
+++ b/pdg/particle.py
@@ -6,10 +6,10 @@ from sqlalchemy import select, bindparam, distinct, func
 from sqlalchemy import and_, or_
 from pdg.errors import PdgApiError, PdgNoDataError, PdgAmbiguousValueError
 from pdg.utils import make_id
-from pdg.data import PdgLifetime, PdgMass, PdgWidth, PdgData
+from pdg.data import PdgLifetime, PdgMass, PdgWidth, PdgData, PdgProperty
 from pdg.units import HBAR_IN_GEV_S
 from sqlalchemy.engine.row import RowMapping
-from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Union
+from typing import TYPE_CHECKING, Iterator, List, Optional, Union
 
 if TYPE_CHECKING:
     from pdg.api import PdgApi
@@ -22,7 +22,7 @@ class PdgItem:
     queried (via the particle/particles properties) for the associated
     particle(s).
     """
-    def __init__(self, api: 'PdgApi', pdgitem_id: int, edition: None=None):
+    def __init__(self, api: 'PdgApi', pdgitem_id: int, edition: Optional[str]=None):
         """Constructor for a PdgItem. Intended for internal API use."""
         self.api = api
         self.pdgitem_id = pdgitem_id
@@ -159,7 +159,8 @@ class PdgParticle(PdgData):
     def _repr_extra(self):
         return "name='%s'" % self.name
 
-    def best(self, properties: Iterator[Any], quantity: Optional[str]=None) -> Union[PdgMass, PdgLifetime, PdgWidth]:
+    def best(self, properties: Iterator[PdgProperty], quantity: Optional[str]=None) \
+            -> PdgProperty:
         """Return the "best" property from an iterable of properties, using the API's pedantic setting.
 
         quantity is an optional string that describes what was being sought in case of error.
@@ -246,7 +247,7 @@ class PdgParticle(PdgData):
     def properties(self,
                    data_type_key: Optional[str]=None,
                    require_summary_data: bool=True,
-                   in_summary_table: None=None,
+                   in_summary_table: Optional[bool]=None,
                    omit_branching_ratios: bool=False):
         """Return iterator over specified particle property data.
 
@@ -321,7 +322,7 @@ class PdgParticle(PdgData):
                     yield prop
 
 
-    def masses(self, require_summary_data: bool=True) -> Iterator[Any]:
+    def masses(self, require_summary_data: bool=True) -> Iterator[PdgMass]:
         """Return iterator over mass data.
 
         For most particles, there is only a single mass property, and so the particle's
@@ -334,15 +335,15 @@ class PdgParticle(PdgData):
         """
         return self.properties('M', require_summary_data)
 
-    def widths(self, require_summary_data: bool=True) -> Iterator[Any]:
+    def widths(self, require_summary_data: bool=True) -> Iterator[PdgWidth]:
         """Return iterator over width data."""
         return self.properties('G', require_summary_data)
 
-    def lifetimes(self, require_summary_data: bool=True) -> Iterator[Any]:
+    def lifetimes(self, require_summary_data: bool=True) -> Iterator[PdgLifetime]:
         """Return iterator over lifetime data."""
         return self.properties('T', require_summary_data)
 
-    def branching_fractions(self, data_type_key='BF%', require_summary_data=True):
+    def branching_fractions(self, data_type_key: str='BF%', require_summary_data: bool=True):
         """Return iterator over given type(s) of branching fraction data.
 
         With data_type_key='BF%' (default), all branching fractions, including subdecay modes, are returned.
@@ -354,7 +355,7 @@ class PdgParticle(PdgData):
             raise PdgApiError('illegal branching fraction data type key %s' % data_type_key)
         return self.properties(data_type_key, require_summary_data)
 
-    def exclusive_branching_fractions(self, include_subdecays=False, require_summary_data=True):
+    def exclusive_branching_fractions(self, include_subdecays: bool=False, require_summary_data: bool=True):
         """Return iterator over exclusive branching fraction data.
 
         Set include_subdecays to True (default is False) to also include
@@ -368,7 +369,7 @@ class PdgParticle(PdgData):
         else:
             return self.branching_fractions('BFX', require_summary_data)
 
-    def inclusive_branching_fractions(self, include_subdecays=False, require_summary_data=True):
+    def inclusive_branching_fractions(self, include_subdecays: bool=False, require_summary_data: bool=True):
         """Return iterator over inclusive branching fraction data.
 
         Set include_subdecays to True (default is False) to also include
@@ -448,12 +449,13 @@ class PdgParticle(PdgData):
         return 'B' in self.data_flags
 
     @staticmethod
-    def _if_not_limit(prop: Union[PdgMass, PdgLifetime, PdgWidth], units: str, error: bool=False) -> float:
+    def _if_not_limit(prop: PdgProperty, units: str, error: bool=False) -> Optional[float]:
         """If a PdgProperty's best summary value is NOT a limit, return it in
         the specified units. Otherwise return None. If error is True, return the
         error instead of the value.
         """
         summary = prop.best_summary()
+        assert summary is not None
         if summary.is_limit:
             return None
         if error:
@@ -461,19 +463,19 @@ class PdgParticle(PdgData):
         return summary.get_value(units)
 
     @property
-    def mass(self) -> float:
+    def mass(self) -> Optional[float]:
         """Mass of the particle in GeV."""
         best_mass_property = self.best(self.masses(), '%s mass (%s)' % (self.name, self.pdgid))
         return self._if_not_limit(best_mass_property, 'GeV')
 
     @property
-    def mass_error(self):
+    def mass_error(self) -> Optional[float]:
         """Symmetric error on mass of particle in GeV, or None if mass error are asymmetric or mass is a limit."""
         best_mass_property = self.best(self.masses(), '%s (%s)' % (self.pdgid, self.description))
         return self._if_not_limit(best_mass_property, 'GeV', error=True)
 
     @property
-    def width(self) -> float:
+    def width(self) -> Optional[float]:
         """Width of the particle in GeV."""
         try:
             best_width_property = self.best(self.widths(), '%s width (%s)' % (self.name, self.pdgid))
@@ -487,7 +489,7 @@ class PdgParticle(PdgData):
             return HBAR_IN_GEV_S / self.lifetime
 
     @property
-    def width_error(self) -> float:
+    def width_error(self) -> Optional[float]:
         """Symmetric error on width of particle in GeV, or None if width error are asymmetric or width is a limit."""
         try:
             best_width_property = self.best(self.widths(), '%s (%s)' % (self.pdgid, self.description))
@@ -498,10 +500,13 @@ class PdgParticle(PdgData):
             # S063 has a lifetime entry but it's NULL
             if (not self.has_lifetime_entry) or (self.lifetime is None):
                 return 0.
-            return self.lifetime_error * HBAR_IN_GEV_S / self.lifetime**2
+            err = self.lifetime_error
+            if err is None:
+                return None
+            return err * HBAR_IN_GEV_S / self.lifetime**2
 
     @property
-    def lifetime(self) -> float:
+    def lifetime(self) -> Optional[float]:
         """Lifetime of the particle in seconds."""
         try:
             best_lifetime_property = self.best(self.lifetimes(), '%s lifetime (%s)' % (self.name, self.pdgid))
@@ -509,12 +514,13 @@ class PdgParticle(PdgData):
         except PdgNoDataError:
             if self.api.pedantic:
                 raise
-            if not self.has_width_entry:
+            width = self.width
+            if width is None:
                 return float('inf')
-            return HBAR_IN_GEV_S / self.width
+            return HBAR_IN_GEV_S / width
 
     @property
-    def lifetime_error(self) -> float:
+    def lifetime_error(self) -> Optional[float]:
         """Symmetric error on lifetime of particle in seconds, or None if lifetime error are asymmetric or lifetime is a limit."""
         try:
             best_lifetime_property = self.best(self.lifetimes(), '%s (%s)' % (self.pdgid, self.description))
@@ -527,10 +533,13 @@ class PdgParticle(PdgData):
                 raise
             if not self.has_width_entry:
                 return 0.
-            return self.width_error * HBAR_IN_GEV_S / self.width**2
+            width, err = self.width, self.width_error
+            if width is None or err is None:
+                return None
+            return err * HBAR_IN_GEV_S / width**2
 
     @property
-    def has_mass_entry(self):
+    def has_mass_entry(self) -> bool:
         """Whether the particle has at least one defined mass."""
         return next(self.masses(), None) is not None
 
@@ -566,7 +575,7 @@ class PdgParticle(PdgData):
             for msmt in t.get_measurements():
                 yield msmt
 
-    def width_measurements(self, require_summary_data=True):
+    def width_measurements(self, require_summary_data: bool=True):
         for g in self.widths(require_summary_data=require_summary_data):
             for msmt in g.get_measurements():
                 yield msmt

--- a/pdg/particle.py
+++ b/pdg/particle.py
@@ -333,15 +333,18 @@ class PdgParticle(PdgData):
         For other particles (e.g. for the top quark) there are different ways to determine the mass and the user
         needs to decide which mass value is the most appropriate for their use case.
         """
-        return self.properties('M', require_summary_data)
+        return cast(Iterator[PdgMass],
+                    self.properties('M', require_summary_data))
 
     def widths(self, require_summary_data: bool=True) -> Iterator[PdgWidth]:
         """Return iterator over width data."""
-        return self.properties('G', require_summary_data)
+        return cast(Iterator[PdgWidth],
+                    self.properties('G', require_summary_data))
 
     def lifetimes(self, require_summary_data: bool=True) -> Iterator[PdgLifetime]:
         """Return iterator over lifetime data."""
-        return self.properties('T', require_summary_data)
+        return cast(Iterator[PdgLifetime],
+                    self.properties('T', require_summary_data))
 
     def branching_fractions(self, data_type_key: str='BF%', require_summary_data: bool=True):
         """Return iterator over given type(s) of branching fraction data.

--- a/pdg/particle.py
+++ b/pdg/particle.py
@@ -9,7 +9,7 @@ from pdg.utils import make_id
 from pdg.data import PdgLifetime, PdgMass, PdgWidth, PdgData, PdgProperty
 from pdg.units import HBAR_IN_GEV_S
 from sqlalchemy.engine.row import RowMapping
-from typing import TYPE_CHECKING, Iterator, List, Optional, Union
+from typing import TYPE_CHECKING, Iterator, List, Optional, Union, cast
 
 if TYPE_CHECKING:
     from pdg.api import PdgApi
@@ -26,7 +26,7 @@ class PdgItem:
         """Constructor for a PdgItem. Intended for internal API use."""
         self.api = api
         self.pdgitem_id = pdgitem_id
-        self.cache = {}
+        self.cache: dict[str, bool | RowMapping] = {}
         self.edition = edition
 
     def __repr__(self):
@@ -44,7 +44,7 @@ class PdgItem:
                 if result is None:
                     raise PdgNoDataError('No PDGITEM entry for %s' % self.pdgitem_id)
                 self.cache['pdgitem'] = result._mapping
-        return self.cache['pdgitem']
+        return cast(RowMapping, self.cache['pdgitem'])
 
     def _get_targets(self):
         """Get all PdgItems that this one maps directly to. Does not recurse."""
@@ -76,7 +76,7 @@ class PdgItem:
                         self.cache['has_particle'] = True
                     else:
                         self.cache['has_particle'] = False
-        return self.cache['has_particle']
+        return cast(bool, self.cache['has_particle'])
 
     @property
     def particle(self) -> 'PdgParticle':
@@ -88,7 +88,7 @@ class PdgItem:
             if self.has_particles:
                 raise PdgAmbiguousValueError('No unique PDGPARTICLE for PDGITEM %s' % self.pdgitem_id)
             raise PdgNoDataError('No PDGPARTICLE for PDGITEM %s' % self.pdgitem_id)
-        p = self.cache['pdgparticle']
+        p = cast(RowMapping, self.cache['pdgparticle'])
         return PdgParticle(self.api, p['pdgid'], edition=self.edition, set_mcid=p['mcid'],
                            set_name=p['name'])
 
@@ -242,7 +242,7 @@ class PdgParticle(PdgData):
                     names = [p.name for p in matches_g]
                     mcids = list(set([p.mcid for p in matches]))
                     raise PdgAmbiguousValueError('Multiple particles for %s: MCID %s, names %s' % (self.baseid, mcids, names))
-        return self.cache['pdgparticle']
+        return cast(RowMapping, self.cache['pdgparticle'])
 
     def properties(self,
                    data_type_key: Optional[str]=None,

--- a/pdg/particle.py
+++ b/pdg/particle.py
@@ -5,14 +5,17 @@ Definition of top-level particle container class.
 from sqlalchemy import select, bindparam, distinct, func
 from sqlalchemy import and_, or_
 from pdg.errors import PdgApiError, PdgNoDataError, PdgAmbiguousValueError
+from pdg.measurement import PdgMeasurement
 from pdg.utils import make_id
 from pdg.data import PdgLifetime, PdgMass, PdgWidth, PdgData, PdgProperty
 from pdg.units import HBAR_IN_GEV_S
 from sqlalchemy.engine.row import RowMapping
-from typing import TYPE_CHECKING, Iterator, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Iterator, Optional, cast
 
 if TYPE_CHECKING:
     from pdg.api import PdgApi
+    from pdg.decay import PdgBranchingFraction
+
 
 class PdgItem:
     """A class to represent an "item" encountered in e.g. a description of a
@@ -29,7 +32,7 @@ class PdgItem:
         self.cache: dict[str, bool | RowMapping] = {}
         self.edition = edition
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return a human-readable representation of the PdgItem."""
         name = self._get_pdgitem()['name']
         return 'PdgItem("%s")' % name
@@ -46,7 +49,7 @@ class PdgItem:
                 self.cache['pdgitem'] = result._mapping
         return cast(RowMapping, self.cache['pdgitem'])
 
-    def _get_targets(self):
+    def _get_targets(self) -> Iterator['PdgItem']:
         """Get all PdgItems that this one maps directly to. Does not recurse."""
         pdgitem_map_table = self.api.db.tables['pdgitem_map']
         query = select(pdgitem_map_table).where(pdgitem_map_table.c.pdgitem_id == bindparam('pdgitem_id'))
@@ -93,7 +96,7 @@ class PdgItem:
                            set_name=p['name'])
 
     @property
-    def particles(self) -> List['PdgParticle']:
+    def particles(self) -> list['PdgParticle']:
         """The list of all particles associated with the PdgItem."""
         if self.has_particle:
             return [self.particle]
@@ -150,13 +153,13 @@ class PdgParticle(PdgData):
         self.set_mcid = set_mcid
         self.set_name = set_name
 
-    def __str__(self):
+    def __str__(self) -> str:
         try:
             return 'Data for PDG Particle %s: %s' % (self.pdgid, self.name)
         except PdgAmbiguousValueError:
             return 'Data for PDG Particle %s: multiple particle matches' % self.pdgid
 
-    def _repr_extra(self):
+    def _repr_extra(self) -> str:
         return "name='%s'" % self.name
 
     def best(self, properties: Iterator[PdgProperty], quantity: Optional[str]=None) \
@@ -248,7 +251,8 @@ class PdgParticle(PdgData):
                    data_type_key: Optional[str]=None,
                    require_summary_data: bool=True,
                    in_summary_table: Optional[bool]=None,
-                   omit_branching_ratios: bool=False):
+                   omit_branching_ratios: bool=False) \
+            -> Iterator[PdgData]:
         """Return iterator over specified particle property data.
 
         By default, all properties excluding branching fractions and branching fraction ratios are returned.
@@ -346,7 +350,8 @@ class PdgParticle(PdgData):
         return cast(Iterator[PdgLifetime],
                     self.properties('T', require_summary_data))
 
-    def branching_fractions(self, data_type_key: str='BF%', require_summary_data: bool=True):
+    def branching_fractions(self, data_type_key: str='BF%', require_summary_data: bool=True) \
+            -> Iterator['PdgBranchingFraction']:
         """Return iterator over given type(s) of branching fraction data.
 
         With data_type_key='BF%' (default), all branching fractions, including subdecay modes, are returned.
@@ -356,9 +361,11 @@ class PdgParticle(PdgData):
         """
         if data_type_key[0:2] != 'BF':
             raise PdgApiError('illegal branching fraction data type key %s' % data_type_key)
-        return self.properties(data_type_key, require_summary_data)
+        return cast(Iterator['PdgBranchingFraction'],
+                    self.properties(data_type_key, require_summary_data))
 
-    def exclusive_branching_fractions(self, include_subdecays: bool=False, require_summary_data: bool=True):
+    def exclusive_branching_fractions(self, include_subdecays: bool=False, require_summary_data: bool=True) \
+            -> Iterator['PdgBranchingFraction']:
         """Return iterator over exclusive branching fraction data.
 
         Set include_subdecays to True (default is False) to also include
@@ -372,7 +379,8 @@ class PdgParticle(PdgData):
         else:
             return self.branching_fractions('BFX', require_summary_data)
 
-    def inclusive_branching_fractions(self, include_subdecays: bool=False, require_summary_data: bool=True):
+    def inclusive_branching_fractions(self, include_subdecays: bool=False, require_summary_data: bool=True) \
+            -> Iterator['PdgBranchingFraction']:
         """Return iterator over inclusive branching fraction data.
 
         Set include_subdecays to True (default is False) to also include
@@ -402,17 +410,17 @@ class PdgParticle(PdgData):
         return self._get_particle_data()['charge']
 
     @property
-    def quantum_I(self):
+    def quantum_I(self) -> str:
         """Quantum number I (isospin) of particle."""
         return self._get_particle_data()['quantum_i']
 
     @property
-    def quantum_G(self):
+    def quantum_G(self) -> str:
         """Quantum number G (G parity) of particle."""
         return self._get_particle_data()['quantum_g']
 
     @property
-    def quantum_J(self):
+    def quantum_J(self) -> str:
         """Quantum number J (spin) of particle."""
         return self._get_particle_data()['quantum_j']
 
@@ -422,7 +430,7 @@ class PdgParticle(PdgData):
         return self._get_particle_data()['quantum_p']
 
     @property
-    def quantum_C(self):
+    def quantum_C(self) -> str:
         """Quantum number C (C parity) of particle."""
         return self._get_particle_data()['quantum_c']
 
@@ -568,17 +576,20 @@ class PdgParticle(PdgData):
         sign = -1 if cc_type == 'A' else 1
         return sign * int(self.charge)
 
-    def mass_measurements(self, require_summary_data: bool=True):
+    def mass_measurements(self, require_summary_data: bool=True) \
+            -> Iterator[PdgMeasurement]:
         for m in self.masses(require_summary_data=require_summary_data):
             for msmt in m.get_measurements():
                 yield msmt
 
-    def lifetime_measurements(self, require_summary_data: bool=True):
+    def lifetime_measurements(self, require_summary_data: bool=True) \
+            -> Iterator[PdgMeasurement]:
         for t in self.lifetimes(require_summary_data=require_summary_data):
             for msmt in t.get_measurements():
                 yield msmt
 
-    def width_measurements(self, require_summary_data: bool=True):
+    def width_measurements(self, require_summary_data: bool=True) \
+            -> Iterator[PdgMeasurement]:
         for g in self.widths(require_summary_data=require_summary_data):
             for msmt in g.get_measurements():
                 yield msmt

--- a/pdg/units.py
+++ b/pdg/units.py
@@ -28,6 +28,7 @@ def convert(value: float, old_units: Optional[str]=None, new_units: Optional[str
     if new_units is None:
         return value
     else:
+        assert old_units is not None
         try:
             old_factor = UNIT_CONVERSION_FACTORS[old_units]
         except KeyError:

--- a/pdg/units.py
+++ b/pdg/units.py
@@ -3,6 +3,7 @@ Constants and utilities for handling HEP units.
 """
 
 from pdg.errors import PdgApiError
+from typing import Optional
 
 HBAR_IN_GEV_S = 6.582E-25
 
@@ -22,7 +23,7 @@ UNIT_CONVERSION_FACTORS = {
 }
 
 
-def convert(value, old_units=None, new_units=None):
+def convert(value: float, old_units: Optional[str]=None, new_units: Optional[str]=None) -> float:
     """Utility to convert value to a different unit."""
     if new_units is None:
         return value

--- a/pdg/utils.py
+++ b/pdg/utils.py
@@ -2,13 +2,15 @@
 Utilities for PDG API.
 """
 import math
+from typing import TYPE_CHECKING, Any, Iterator, Optional, Tuple
 
 from sqlalchemy import select, bindparam
+from sqlalchemy.engine.row import RowMapping
 
 from pdg.errors import PdgNoDataError, PdgAmbiguousValueError, PdgRoundingError
-from pdg.api import PdgApi
-from sqlalchemy.engine.row import RowMapping
-from typing import Optional, Tuple, Union
+
+if TYPE_CHECKING:
+    from pdg.api import PdgApi
 
 
 def pdg_round(value: float, error: float) -> Tuple[float, float]:
@@ -35,7 +37,7 @@ def pdg_round(value: float, error: float) -> Tuple[float, float]:
     return new_value, new_error
 
 
-def parse_id(pdgid: str) -> Union[Tuple[str, str], Tuple[str, None]]:
+def parse_id(pdgid: str) -> Tuple[str, Optional[str]]:
     """Parse PDG Identifier and return (normalized base identifier, edition)."""
     try:
         baseid, edition = pdgid.split('/')
@@ -62,7 +64,7 @@ def make_id(baseid: str, edition: Optional[str]=None) -> str:
 
 
 
-def get_row_data(api: PdgApi, table_name: str, row_id: int) -> RowMapping:
+def get_row_data(api: 'PdgApi', table_name: str, row_id: int) -> RowMapping:
     """Return dict built from the row of the specified table that has an id of
     row_id.
     """
@@ -74,7 +76,8 @@ def get_row_data(api: PdgApi, table_name: str, row_id: int) -> RowMapping:
     return matches[0]._mapping
 
 
-def get_linked_ids(api: PdgApi, table_name: str, src_col: str, src_id: int, dest_col: str='id'):
+def get_linked_ids(api: 'PdgApi', table_name: str, src_col: str, src_id: int, dest_col: str='id') \
+        -> Iterator[Any]:
     """Return iterator over all values of dest_col in the specified table for which
     src_col = src_id.
     """

--- a/pdg/utils.py
+++ b/pdg/utils.py
@@ -6,9 +6,12 @@ import math
 from sqlalchemy import select, bindparam
 
 from pdg.errors import PdgNoDataError, PdgAmbiguousValueError, PdgRoundingError
+from pdg.api import PdgApi
+from sqlalchemy.engine.row import RowMapping
+from typing import Optional, Tuple, Union
 
 
-def pdg_round(value, error):
+def pdg_round(value: float, error: float) -> Tuple[float, float]:
     """Return (value, error) as numbers rounded following PDG rounding rules."""
     # FIXME: might switch to returning decimal.Decimal rather than floats
     if error <= 0.:
@@ -32,7 +35,7 @@ def pdg_round(value, error):
     return new_value, new_error
 
 
-def parse_id(pdgid):
+def parse_id(pdgid: str) -> Union[Tuple[str, str], Tuple[str, None]]:
     """Parse PDG Identifier and return (normalized base identifier, edition)."""
     try:
         baseid, edition = pdgid.split('/')
@@ -42,12 +45,12 @@ def parse_id(pdgid):
     return baseid.upper(), edition
 
 
-def base_id(pdgid):
+def base_id(pdgid: str) -> str:
     """Return normalized base part of PDG Identifier."""
     return parse_id(pdgid)[0]
 
 
-def make_id(baseid, edition=None):
+def make_id(baseid: str, edition: Optional[str]=None) -> str:
     """Return normalized full PDG Identifier, possibly including edition."""
     if baseid is None:
         return None
@@ -59,7 +62,7 @@ def make_id(baseid, edition=None):
 
 
 
-def get_row_data(api, table_name, row_id):
+def get_row_data(api: PdgApi, table_name: str, row_id: int) -> RowMapping:
     """Return dict built from the row of the specified table that has an id of
     row_id.
     """
@@ -71,7 +74,7 @@ def get_row_data(api, table_name, row_id):
     return matches[0]._mapping
 
 
-def get_linked_ids(api, table_name, src_col, src_id, dest_col='id'):
+def get_linked_ids(api: PdgApi, table_name: str, src_col: str, src_id: int, dest_col: str='id'):
     """Return iterator over all values of dest_col in the specified table for which
     src_col = src_id.
     """

--- a/pdg/utils.py
+++ b/pdg/utils.py
@@ -2,7 +2,7 @@
 Utilities for PDG API.
 """
 import math
-from typing import TYPE_CHECKING, Any, Iterator, Optional, Tuple
+from typing import TYPE_CHECKING, Iterator, Optional, Tuple, cast
 
 from sqlalchemy import select, bindparam
 from sqlalchemy.engine.row import RowMapping
@@ -62,8 +62,6 @@ def make_id(baseid: str, edition: Optional[str]=None) -> str:
         return ('%s/%s' % (baseid, edition)).upper()
 
 
-
-
 def get_row_data(api: 'PdgApi', table_name: str, row_id: int) -> RowMapping:
     """Return dict built from the row of the specified table that has an id of
     row_id.
@@ -77,13 +75,13 @@ def get_row_data(api: 'PdgApi', table_name: str, row_id: int) -> RowMapping:
 
 
 def get_linked_ids(api: 'PdgApi', table_name: str, src_col: str, src_id: int, dest_col: str='id') \
-        -> Iterator[Any]:
+        -> Iterator[int]:
     """Return iterator over all values of dest_col in the specified table for which
-    src_col = src_id.
+    src_col = src_id; dest_col is assumed to be an ID column (i.e. an int)
     """
     table = api.db.tables[table_name]
     query = select(table.c[dest_col]) \
         .where(table.c[src_col] == bindparam('src_id'))
     with api.engine.connect() as conn:
         for entry in conn.execute(query, {'src_id': src_id}):
-            yield entry._mapping[dest_col]
+            yield cast(int, entry._mapping[dest_col])

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
         'Environment :: Console',
         'Intended Audience :: Science/Research',
         'Intended Audience :: Developers',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Topic :: Database :: Front-Ends',
         'Topic :: Scientific/Engineering',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(
     license='Modified BSD',
     packages=find_packages(),
     package_data={"pdg": ["pdg.sqlite"]},
-    install_requires=['SQLAlchemy>=1.4'],
+    install_requires=['SQLAlchemy>=1.4', 'typing_extensions>=4.15'],
+    python_requires='>=3.10',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',


### PR DESCRIPTION
This adds type annotations to all function and method signatures, bumps the minimum supported Python version to 3.10, drops Python 2.7 from the classifiers in setup.py, and adds `typing_extensions` as a new dependency (currently just for the `@deprecated` decorator, but going forward, `typing_extensions` will ensure that supporting 3.10 doesn't limit the degree to which the code can be made "type-safe"). The annotated code has been checked with ty, mypy, and pylance.

During this process, it was realized that `PdgFootnote.references` would more sensibly be named `PdgFootnote.measurements`, given that it returns `PdgMeasurements` and not `PdgReferencess`, so that's where `@deprecated` came in handy.