### PR TITLE
Remove unquoted forward ref in type annotation

### DIFF
--- a/pdg/particle.py
+++ b/pdg/particle.py
@@ -744,7 +744,7 @@ class PdgParticle(PdgData):
         return cc_type == 'S'
 
     @property
-    def antiparticle(self) -> PdgParticle:
+    def antiparticle(self) -> 'PdgParticle':
         "This particle's antiparticle (or itself, if self-conjugate)"
         if self.self_conjugate:
             return self


### PR DESCRIPTION
This removes an unquoted forward reference in the `PdgParticle.antiparticle` type annotation. It was causing an error during import on Python < 3.14.